### PR TITLE
Fix GitHub Pages deployment permissions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,9 +5,20 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    concurrency:
+      group: github-pages
+      cancel-in-progress: true
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -32,4 +43,5 @@ jobs:
           path: ./dist
 
       - name: Deploy to GitHub Pages
+        id: deployment
         uses: actions/deploy-pages@v1


### PR DESCRIPTION
## Summary
- grant the GitHub Pages workflow the required token permissions for deployment
- configure the deployment job environment and concurrency to match GitHub Pages requirements

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e119456fa8832f900f23e3ef0c6d46