### PR TITLE
Add tabbed navigation for portfolio workspace

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,5 @@
+server/**
+.github/**
+index.html
+tailwind.config.js
+vite.config.js

--- a/README.md
+++ b/README.md
@@ -1,15 +1,30 @@
 # Portfolio Manager (Server Edition)
 
-This project provides a full‑stack portfolio manager that runs client‑side in the browser but persists data on the server.  It allows you to record transactions (buy, sell, dividends, deposits and withdrawals) using amounts and exact prices, computes holdings and portfolio value, tracks return on investment (ROI) relative to the S&P 500 (SPY) and displays configurable trading signals for each ticker.
+This project provides a full‑stack portfolio manager that runs client‑side in the browser but persists data on the server. It allows you to record transactions (buy, sell, dividends, deposits and withdrawals) using amounts and exact prices, computes holdings and portfolio value, tracks return on investment (ROI) relative to the S&P 500 (SPY) and displays configurable trading signals for each ticker.
 
 ## Features
 
 - **Server‑side persistence** – save and load your portfolio on any device via REST endpoints.
+- **Tabbed workspace** – switch between Dashboard, Holdings and Transactions views without losing context.
 - **Transaction entry** – enter date, ticker, transaction type, amount invested and price; the app calculates shares automatically.
 - **Holdings dashboard** – see average cost, current value, unrealised/realised PnL, ROI and position weights.
 - **Signals per ticker** – define a percentage band around the last price to trigger buy/trim/hold signals.
 - **ROI vs SPY** – chart your portfolio’s performance against SPY using daily price data from Stooq (no API key required).
 - **Responsive, dark mode UI** built with React, Tailwind CSS and Recharts.
+
+### Frontend configuration
+
+| Name            | Type         | Default                                            | Required | Description                                                                   |
+| --------------- | ------------ | -------------------------------------------------- | -------- | ----------------------------------------------------------------------------- |
+| `VITE_API_BASE` | string (URL) | `https://portfolio-api.carlosortega77.workers.dev` | No       | Overrides the API host used by the Dashboard, Holdings and Transactions tabs. |
+
+### Tabbed navigation
+
+The interface organises the experience across three focused tabs:
+
+- **Dashboard** – portfolio KPIs, ROI vs. SPY line chart, and quick actions to refresh analytics or open reference material.
+- **Holdings** – consolidated holdings table plus configurable buy/trim signal bands for each ticker.
+- **Transactions** – dedicated form for capturing trades and a chronological activity table.
 
 ## Getting Started
 
@@ -27,15 +42,15 @@ This project provides a full‑stack portfolio manager that runs client‑side i
    npm run server
    ```
 
-   The server validates portfolio identifiers to the pattern `[A-Za-z0-9_-]{1,64}` to prevent path traversal.  Requests with invalid identifiers return `400`.
+   The server validates portfolio identifiers to the pattern `[A-Za-z0-9_-]{1,64}` to prevent path traversal. Requests with invalid identifiers return `400`.
 
    Configuration is provided via environment variables:
 
-   | Name | Type | Default | Required | Description |
-   | ---- | ---- | ------- | -------- | ----------- |
-   | `PORT` | number | `3000` | No | TCP port for the Express server. |
-   | `DATA_DIR` | string (path) | `./data` | No | Directory for persisted portfolio files. |
-   | `PRICE_FETCH_TIMEOUT_MS` | number | `5000` | No | Timeout in milliseconds for upstream price fetches. |
+   | Name                     | Type          | Default  | Required | Description                                         |
+   | ------------------------ | ------------- | -------- | -------- | --------------------------------------------------- |
+   | `PORT`                   | number        | `3000`   | No       | TCP port for the Express server.                    |
+   | `DATA_DIR`               | string (path) | `./data` | No       | Directory for persisted portfolio files.            |
+   | `PRICE_FETCH_TIMEOUT_MS` | number        | `5000`   | No       | Timeout in milliseconds for upstream price fetches. |
 
    Price data is fetched from [Stooq](https://stooq.com/).
 
@@ -48,10 +63,11 @@ This project provides a full‑stack portfolio manager that runs client‑side i
    Vite runs on port `5173` and proxies `/api` calls to the backend.
 
 4. **Usage:**
-
-   - Add transactions via the form.  Enter **amount** and **price**; shares are computed automatically.
-   - Configure signals for each ticker by clicking the **Signals** tab.  Percentage windows determine when the last price falls below or above your buy/trim zones.
-   - Save/load your portfolio by choosing a portfolio ID and pressing **Save** or **Load**.  Portfolios are stored in the backend’s `data/` folder.
+   - Navigate using the tab bar at the top of the workspace. The active tab is persisted while you save or load data.
+   - Add transactions via the **Transactions** tab. Enter **amount** and **price**; shares are computed automatically before submission.
+   - Review metrics, ROI performance and quick actions from the **Dashboard** tab.
+   - Configure signals and monitor allocation details from the **Holdings** tab. Percentage windows determine when the last price falls below or above your buy/trim zones.
+   - Save or load your portfolio by choosing a portfolio ID and pressing **Save** or **Load**. Portfolios are stored in the backend’s `data/` folder.
 
 ### Production Deployment
 
@@ -63,15 +79,15 @@ To deploy the static frontend to GitHub Pages and run the backend separately:
    npm run build
    ```
 
-2. Serve the files in `dist/` from your static host (GitHub Pages, Netlify, etc.).  If using GitHub Pages, set the `base` path in `vite.config.js` or define `VITE_BASE=/your-repo/` at build time.
+2. Serve the files in `dist/` from your static host (GitHub Pages, Netlify, etc.). If using GitHub Pages, set the `base` path in `vite.config.js` or define `VITE_BASE=/your-repo/` at build time.
 
-3. Deploy the backend to your preferred host (Heroku, Railway, Cloudflare Workers with minimal adjustments).  For Cloudflare Workers, you can port the express logic to `fetch` handlers and use KV for storage.
+3. Deploy the backend to your preferred host (Heroku, Railway, Cloudflare Workers with minimal adjustments). For Cloudflare Workers, you can port the express logic to `fetch` handlers and use KV for storage.
 
 ## API
 
 ### `GET /api/prices/:symbol?range=1y`
 
-Returns an array of historical prices for a US ticker using Stooq.  Supported query parameters:
+Returns an array of historical prices for a US ticker using Stooq. Supported query parameters:
 
 - `range` – currently only `1y` (one year of daily data) is supported.
 
@@ -87,12 +103,12 @@ Example response:
 
 ### `GET /api/portfolio/:id`
 
-Loads a saved portfolio with the given `id` from the `data` folder.  The identifier must match `[A-Za-z0-9_-]{1,64}`; otherwise the request is rejected with HTTP `400`.  Returns an empty object if the portfolio does not exist.
+Loads a saved portfolio with the given `id` from the `data` folder. The identifier must match `[A-Za-z0-9_-]{1,64}`; otherwise the request is rejected with HTTP `400`. Returns an empty object if the portfolio does not exist.
 
 ### `POST /api/portfolio/:id`
 
-Saves a portfolio to the backend.  The request body must be a JSON object representing your portfolio state.  The identifier is validated using the same `[A-Za-z0-9_-]{1,64}` rule, and payloads that are not plain JSON objects return HTTP `400`.  Valid portfolios are stored as `data/portfolio_<id>.json`.
+Saves a portfolio to the backend. The request body must be a JSON object representing your portfolio state. The identifier is validated using the same `[A-Za-z0-9_-]{1,64}` rule, and payloads that are not plain JSON objects return HTTP `400`. Valid portfolios are stored as `data/portfolio_<id>.json`.
 
 ## Contributing
 
-Feel free to fork this repository and customise it to your needs.  Pull requests are welcome!
+Feel free to fork this repository and customise it to your needs. Pull requests are welcome!

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,21 +1,27 @@
-import js from '@eslint/js';
-import globals from 'globals';
+import js from "@eslint/js";
+import globals from "globals";
 
 export default [
   {
-    ignores: ['node_modules/**', 'dist/**'],
+    ignores: ["node_modules/**", "dist/**"],
   },
   js.configs.recommended,
   {
     languageOptions: {
-      sourceType: 'module',
+      sourceType: "module",
       ecmaVersion: 2022,
+      parserOptions: {
+        ecmaFeatures: {
+          jsx: true,
+        },
+      },
       globals: {
         ...globals.node,
+        ...globals.browser,
       },
     },
     rules: {
-      'no-console': 'off',
+      "no-console": "off",
     },
   },
 ];

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,11 +19,15 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.11.1",
+        "@testing-library/react": "^14.1.2",
+        "@testing-library/user-event": "^14.4.3",
         "@vitejs/plugin-react": "^4.0.0",
         "autoprefixer": "^10.4.15",
         "eslint": "^9.11.1",
         "globals": "^15.9.0",
+        "jsdom": "^24.0.0",
         "postcss": "^8.4.33",
+        "prettier": "^3.2.5",
         "supertest": "^7.0.0",
         "tailwindcss": "^3.3.5",
         "vite": "^5.0.0"
@@ -41,6 +45,27 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-3.2.0.tgz",
+      "integrity": "sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^2.1.3",
+        "@csstools/css-color-parser": "^3.0.9",
+        "@csstools/css-parser-algorithms": "^3.0.4",
+        "@csstools/css-tokenizer": "^3.0.3",
+        "lru-cache": "^10.4.3"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/@babel/code-frame": {
       "version": "7.27.1",
@@ -331,6 +356,121 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.1.0.tgz",
+      "integrity": "sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-2.1.4.tgz",
+      "integrity": "sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-3.1.0.tgz",
+      "integrity": "sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^5.1.0",
+        "@csstools/css-calc": "^2.1.4"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz",
+      "integrity": "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz",
+      "integrity": "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -1445,6 +1585,97 @@
         "win32"
       ]
     },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/react": {
+      "version": "14.3.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-14.3.1.tgz",
+      "integrity": "sha512-H99XjUhWQw0lTgyMN05W3xQG1Nh4lq574D8keFf1dDoNTJgp66VbJozRaczoF+wsiaPJNt/TcnfpLGufGxSrZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5",
+        "@testing-library/dom": "^9.0.0",
+        "@types/react-dom": "^18.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0",
+        "react-dom": "^18.0.0"
+      }
+    },
+    "node_modules/@testing-library/react/node_modules/@testing-library/dom": {
+      "version": "9.3.4",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-9.3.4.tgz",
+      "integrity": "sha512-FlS4ZWlp97iiNWig0Muq8p+3rVDjRiYE+YKGbAqXOu9nwJFFOdL00kFpz42M+4huzYi86vAK1sOOfyOG45muIQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.1.3",
+        "chalk": "^4.1.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@testing-library/react/node_modules/aria-query": {
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.1.3.tgz",
+      "integrity": "sha512-R5iJ5lkuHybztUfuOAznmboyjWq8O6sqNqtK7CLOqdydi54VNbORp49mb14KbWgG1QD3JFO9hJdZ+y4KutfdOQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "deep-equal": "^2.0.5"
+      }
+    },
+    "node_modules/@testing-library/user-event": {
+      "version": "14.6.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.1.tgz",
+      "integrity": "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=7.21.4"
+      }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -1567,6 +1798,36 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/prop-types": {
+      "version": "15.7.15",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
+      "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@types/react": {
+      "version": "18.3.25",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.25.tgz",
+      "integrity": "sha512-oSVZmGtDPmRZtVDqvdKUi/qgCsWp5IDY29wp8na8Bj4B3cc99hfNzvNhlMkVVxctkAOGUA3Km7MMpBHAnWfcIA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/prop-types": "*",
+        "csstype": "^3.0.2"
+      }
+    },
+    "node_modules/@types/react-dom": {
+      "version": "18.3.7",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
+      "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "^18.0.0"
+      }
+    },
     "node_modules/@vitejs/plugin-react": {
       "version": "4.7.0",
       "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-4.7.0.tgz",
@@ -1622,6 +1883,16 @@
       "license": "MIT",
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/ajv": {
@@ -1702,6 +1973,34 @@
       "dev": true,
       "license": "Python-2.0"
     },
+    "node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
+    "node_modules/array-buffer-byte-length": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/array-buffer-byte-length/-/array-buffer-byte-length-1.0.2.tgz",
+      "integrity": "sha512-LHE+8BuR7RYGDKvnrmcuSq3tDcKv9OFEXQt/HpbZhY7V6h0zlUXutnAD82GiFx9rdieCMjkvtcsPqBwgUl1Iiw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "is-array-buffer": "^3.0.5"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/array-flatten": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
@@ -1758,6 +2057,22 @@
       },
       "peerDependencies": {
         "postcss": "^8.1.0"
+      }
+    },
+    "node_modules/available-typed-arrays": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
+      "integrity": "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "possible-typed-array-names": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/balanced-match": {
@@ -1893,6 +2208,25 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz",
+      "integrity": "sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.0",
+        "es-define-property": "^1.0.0",
+        "get-intrinsic": "^1.2.4",
+        "set-function-length": "^1.2.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/call-bind-apply-helpers": {
@@ -2196,6 +2530,27 @@
         "node": ">=4"
       }
     },
+    "node_modules/cssstyle": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-4.6.0.tgz",
+      "integrity": "sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^3.2.0",
+        "rrweb-cssom": "^0.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/cssstyle/node_modules/rrweb-cssom": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz",
+      "integrity": "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/csstype": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
@@ -2332,6 +2687,20 @@
         "node": ">= 12"
       }
     },
+    "node_modules/data-urls": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-5.0.0.tgz",
+      "integrity": "sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -2350,11 +2719,51 @@
         }
       }
     },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/decimal.js-light": {
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
       "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==",
       "license": "MIT"
+    },
+    "node_modules/deep-equal": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-2.2.3.tgz",
+      "integrity": "sha512-ZIwpnevOurS8bpT4192sqAowWM76JDKSHYzMLty3BZGSswgq6pBaH3DhCSW5xVAZICZyKdOBPjwww5wfgT/6PA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array-buffer-byte-length": "^1.0.0",
+        "call-bind": "^1.0.5",
+        "es-get-iterator": "^1.1.3",
+        "get-intrinsic": "^1.2.2",
+        "is-arguments": "^1.1.1",
+        "is-array-buffer": "^3.0.2",
+        "is-date-object": "^1.0.5",
+        "is-regex": "^1.1.4",
+        "is-shared-array-buffer": "^1.0.2",
+        "isarray": "^2.0.5",
+        "object-is": "^1.1.5",
+        "object-keys": "^1.1.1",
+        "object.assign": "^4.1.4",
+        "regexp.prototype.flags": "^1.5.1",
+        "side-channel": "^1.0.4",
+        "which-boxed-primitive": "^1.0.2",
+        "which-collection": "^1.0.1",
+        "which-typed-array": "^1.1.13"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/deep-is": {
       "version": "0.1.4",
@@ -2362,6 +2771,42 @@
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/define-data-property": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
+      "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-define-property": "^1.0.0",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/define-properties": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
+      "integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.0.1",
+        "has-property-descriptors": "^1.0.0",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/delayed-stream": {
       "version": "1.0.0",
@@ -2380,6 +2825,17 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/destroy": {
@@ -2414,6 +2870,13 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/dlv/-/dlv-1.1.3.tgz",
       "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
       "license": "MIT"
     },
@@ -2477,6 +2940,19 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
     "node_modules/es-define-property": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
@@ -2493,6 +2969,27 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-get-iterator": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/es-get-iterator/-/es-get-iterator-1.1.3.tgz",
+      "integrity": "sha512-sPZmqHBe6JIiTfN5q2pEi//TwxmAFHwj/XEuYjTuse78i8KxaqMTTzxPoFKuzRpDpTJ+0NAbpfenkmH2rePtuw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "get-intrinsic": "^1.1.3",
+        "has-symbols": "^1.0.3",
+        "is-arguments": "^1.1.1",
+        "is-map": "^2.0.2",
+        "is-set": "^2.0.2",
+        "is-string": "^1.0.7",
+        "isarray": "^2.0.5",
+        "stop-iteration-iterator": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/es-object-atoms": {
@@ -3043,6 +3540,22 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/for-each": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
+      "integrity": "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-callable": "^1.2.7"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/foreground-child": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
@@ -3163,6 +3676,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/functions-have-names": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.3.tgz",
+      "integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/gensync": {
       "version": "1.0.0-beta.2",
       "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
@@ -3269,6 +3792,19 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/has-bigints": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.1.0.tgz",
+      "integrity": "sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -3277,6 +3813,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/has-property-descriptors": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+      "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-define-property": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/has-symbols": {
@@ -3319,6 +3868,19 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
+      "integrity": "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-encoding": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/http-errors": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
@@ -3333,6 +3895,34 @@
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/iconv-lite": {
@@ -3390,6 +3980,21 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "license": "ISC"
     },
+    "node_modules/internal-slot": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.1.0.tgz",
+      "integrity": "sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "hasown": "^2.0.2",
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/internmap": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
@@ -3408,6 +4013,57 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/is-arguments": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.2.0.tgz",
+      "integrity": "sha512-7bVbi0huj/wrIAOzb8U1aszg9kdi3KN/CyU19CTI7tAoZYEZoL9yCDXpbXN+uPsuWnP02cyug1gleqq+TU+YCA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-array-buffer": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.5.tgz",
+      "integrity": "sha512-DDfANUiiG2wC1qawP66qlTugJeL5HyzMpfr8lLK+jMQirGzNod0B12cFB/9q838Ru27sBwfw78/rdoU7RERz6A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "get-intrinsic": "^1.2.6"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-bigint": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.1.0.tgz",
+      "integrity": "sha512-n4ZT37wG78iz03xPRKJrHTdZbe3IicyucEtdRsV5yglwc3GyUfbAfpSeD0FJ41NbUNSt5wbhqfp1fS+BgnvDFQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-bigints": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-binary-path": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
@@ -3421,6 +4077,36 @@
         "node": ">=8"
       }
     },
+    "node_modules/is-boolean-object": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.2.2.tgz",
+      "integrity": "sha512-wa56o2/ElJMYqjCjGkXri7it5FbebW5usLw/nPmCMs5DeZ7eziSYZhSmPRn0txqeW4LnAmQQU7FgqLpsEFKM4A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-callable": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
+      "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-core-module": {
       "version": "2.16.1",
       "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
@@ -3429,6 +4115,23 @@
       "license": "MIT",
       "dependencies": {
         "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-date-object": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.1.0.tgz",
+      "integrity": "sha512-PwwhEakHVKTdRNVOw+/Gyh0+MzlCl4R6qKvkhuvLtPMggI1WAHt9sOwZxQLSGpUaDnrdyDsomoRgNnCfKNSXXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "has-tostringtag": "^1.0.2"
       },
       "engines": {
         "node": ">= 0.4"
@@ -3470,6 +4173,19 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-map": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.3.tgz",
+      "integrity": "sha512-1Qed0/Hr2m+YqxnM09CjA2d/i6YZNfF6R2oRAOj36eUdS6qIV/huPJNSEpKbupewFs+ZsJlxsjjPbc0/afW6Lw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-number": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
@@ -3479,6 +4195,150 @@
       "engines": {
         "node": ">=0.12.0"
       }
+    },
+    "node_modules/is-number-object": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.1.1.tgz",
+      "integrity": "sha512-lZhclumE1G6VYD8VHe35wFaIif+CTy5SJIi5+3y4psDgWu4wPDoBhF8NxUOinEc7pHgiTsT6MaBb92rKhhD+Xw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/is-regex": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
+      "integrity": "sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "gopd": "^1.2.0",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-set": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/is-set/-/is-set-2.0.3.tgz",
+      "integrity": "sha512-iPAjerrse27/ygGLxw+EBR9agv9Y6uLeYVJMu+QNCoouJ1/1ri0mGrcWpfCqFZuzzx3WjtwxG098X+n4OuRkPg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-shared-array-buffer": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.4.tgz",
+      "integrity": "sha512-ISWac8drv4ZGfwKl5slpHG9OwPNty4jOWPRIhBpxOoD+hqITiwuipOQ2bNthAzwA3B4fIjO4Nln74N0S9byq8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-string": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.1.1.tgz",
+      "integrity": "sha512-BtEeSsoaQjlSPBemMQIrY1MY0uM6vnS1g5fmufYOtnxLGUZM2178PKbhsk7Ffv58IX+ZtcvoGwccYsh0PglkAA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-symbol": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.1.1.tgz",
+      "integrity": "sha512-9gGx6GTtCQM73BgmHQXfDmLtfjjTUDSyoxTCbp5WtoixAhfgsDirWIcVQ/IHpvI5Vgd5i/J5F7B9cN/WlVbC/w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "has-symbols": "^1.1.0",
+        "safe-regex-test": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-weakmap": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/is-weakmap/-/is-weakmap-2.0.2.tgz",
+      "integrity": "sha512-K5pXYOm9wqY1RgjpL3YTkF39tni1XajUIkawTLUo9EZEVUFga5gSQJF8nNS7ZwJQ02y+1YCNYcMh+HIf1ZqE+w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-weakset": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/is-weakset/-/is-weakset-2.0.4.tgz",
+      "integrity": "sha512-mfcwb6IzQyOKTs84CQMrOwW4gQcaTOAWJ0zzJCl2WSPDrWk/OzDaImWFH3djXhb24g4eudZfLRozAvPGw4d9hQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "get-intrinsic": "^1.2.6"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/isarray": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/isexe": {
       "version": "2.0.0",
@@ -3530,6 +4390,47 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsdom": {
+      "version": "24.1.3",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-24.1.3.tgz",
+      "integrity": "sha512-MyL55p3Ut3cXbeBEG7Hcv0mVM8pp8PBNWxRqchZnSfAiES1v1mRnMeFfaHWIPULpwsYfvO+ZmMZz5tGCnjzDUQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cssstyle": "^4.0.1",
+        "data-urls": "^5.0.0",
+        "decimal.js": "^10.4.3",
+        "form-data": "^4.0.0",
+        "html-encoding-sniffer": "^4.0.0",
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.5",
+        "is-potential-custom-element-name": "^1.0.1",
+        "nwsapi": "^2.2.12",
+        "parse5": "^7.1.2",
+        "rrweb-cssom": "^0.7.1",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^4.1.4",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^7.0.0",
+        "whatwg-encoding": "^3.1.1",
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.0.0",
+        "ws": "^8.18.0",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "canvas": "^2.11.2"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
       }
     },
     "node_modules/jsesc": {
@@ -3672,6 +4573,16 @@
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "lz-string": "bin/bin.js"
       }
     },
     "node_modules/math-intrinsics": {
@@ -3911,6 +4822,13 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/nwsapi": {
+      "version": "2.2.22",
+      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.22.tgz",
+      "integrity": "sha512-ujSMe1OWVn55euT1ihwCI1ZcAaAU3nxUiDwfDQldc51ZXaB9m2AyOn6/jh1BLe2t/G8xd6uKG1UBF2aZJeg2SQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -3935,6 +4853,54 @@
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
       "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
       "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/object-is": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.6.tgz",
+      "integrity": "sha512-F8cZ+KfGlSGi09lJT7/Nd6KJZ9ygtvYC0/UYYLI9nmQKLMnydpB9yvbv9K1uSkEu7FU9vYPmVwLg328tX+ot3Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/object-keys": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/object.assign": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.7.tgz",
+      "integrity": "sha512-nK28WOo+QIjBkDduTINE4JkF/UJJKyf2EJxvJKfblDpyg0Q+pkOHNTL0Qwy6NP6FhE/EnzV73BxxqcJaXY9anw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.0.0",
+        "has-symbols": "^1.1.0",
+        "object-keys": "^1.1.1"
+      },
       "engines": {
         "node": ">= 0.4"
       },
@@ -4032,6 +4998,19 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
       }
     },
     "node_modules/parseurl": {
@@ -4138,6 +5117,16 @@
       "license": "MIT",
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/possible-typed-array-names": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
+      "integrity": "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/postcss": {
@@ -4313,6 +5302,67 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/prettier": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.6.2.tgz",
+      "integrity": "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/pretty-format/node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/prop-types": {
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
@@ -4343,6 +5393,19 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/psl": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.15.0.tgz",
+      "integrity": "sha512-JZd3gMVBAVQkSs6HdNZo9Sdo0LNcQeMNP3CozBJb3JYC/QUYZTnKxP+f8oWRX4rHP5EurWxqAHTSwUCjlNKa1w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/lupomontero"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -4367,6 +5430,13 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/querystringify": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
+      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
@@ -4581,6 +5651,34 @@
         "node": ">=6"
       }
     },
+    "node_modules/regexp.prototype.flags": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.4.tgz",
+      "integrity": "sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-errors": "^1.3.0",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "set-function-name": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/requires-port": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+      "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/resolve": {
       "version": "1.22.10",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.10.tgz",
@@ -4665,6 +5763,13 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/rrweb-cssom": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.7.1.tgz",
+      "integrity": "sha512-TrEMa7JGdVm0UThDJSx7ddw5nVm3UJS9o9CCIZ72B1vSyEZoziDqBYP3XIoi/12lKrJR8rE3jeFHMok2F/Mnsg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/run-parallel": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -4709,11 +5814,42 @@
       ],
       "license": "MIT"
     },
+    "node_modules/safe-regex-test": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.1.0.tgz",
+      "integrity": "sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "is-regex": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "license": "MIT"
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
     },
     "node_modules/scheduler": {
       "version": "0.23.2",
@@ -4795,6 +5931,40 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/set-function-length": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
+      "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.1.4",
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2",
+        "get-intrinsic": "^1.2.4",
+        "gopd": "^1.0.1",
+        "has-property-descriptors": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/set-function-name": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/set-function-name/-/set-function-name-2.0.2.tgz",
+      "integrity": "sha512-7PGFlmtwsEADb0WYyvCMa1t+yke6daIG4Wirafur5kcf+MhUnPms1UeR0CKQdTZD81yESwMHbtn+TR+dMviakQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.1.4",
+        "es-errors": "^1.3.0",
+        "functions-have-names": "^1.2.3",
+        "has-property-descriptors": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/setprototypeof": {
@@ -4928,6 +6098,20 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/stop-iteration-iterator": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/stop-iteration-iterator/-/stop-iteration-iterator-1.1.0.tgz",
+      "integrity": "sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "internal-slot": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/string-width": {
@@ -5144,6 +6328,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tailwindcss": {
       "version": "3.4.18",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.18.tgz",
@@ -5233,6 +6424,35 @@
         "node": ">=0.6"
       }
     },
+    "node_modules/tough-cookie": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.4.tgz",
+      "integrity": "sha512-Loo5UUvLD9ScZ6jh8beX1T6sO1w2/MpCRpEP7V280GKMVUQ0Jzar2U3UJPsrdbziLEMMhu3Ujnq//rhiFuIeag==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "psl": "^1.1.33",
+        "punycode": "^2.1.1",
+        "universalify": "^0.2.0",
+        "url-parse": "^1.5.3"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
+      "integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/ts-interface-checker": {
       "version": "0.1.13",
       "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
@@ -5264,6 +6484,16 @@
       },
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/universalify": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.2.0.tgz",
+      "integrity": "sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4.0.0"
       }
     },
     "node_modules/unpipe": {
@@ -5314,6 +6544,17 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/url-parse": {
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
+      "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "querystringify": "^2.1.1",
+        "requires-port": "^1.0.0"
       }
     },
     "node_modules/util-deprecate": {
@@ -5423,6 +6664,19 @@
         }
       }
     },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/web-streams-polyfill": {
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
@@ -5430,6 +6684,66 @@
       "license": "MIT",
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/whatwg-encoding": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-encoding/node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
+      "integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "^5.1.0",
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/which": {
@@ -5446,6 +6760,67 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/which-boxed-primitive": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.1.1.tgz",
+      "integrity": "sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-bigint": "^1.1.0",
+        "is-boolean-object": "^1.2.1",
+        "is-number-object": "^1.1.1",
+        "is-string": "^1.1.1",
+        "is-symbol": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/which-collection": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/which-collection/-/which-collection-1.0.2.tgz",
+      "integrity": "sha512-K4jVyjnBdgvc86Y6BkaLZEN933SwYOuBFkdmBu9ZfkcAbdVbpITnDmjvZ/aQjRXQrv5EPkTnD1s39GiiqbngCw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-map": "^2.0.3",
+        "is-set": "^2.0.3",
+        "is-weakmap": "^2.0.2",
+        "is-weakset": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/which-typed-array": {
+      "version": "1.1.19",
+      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.19.tgz",
+      "integrity": "sha512-rEvr90Bck4WZt9HHFC4DJMsjvu7x+r6bImz0/BrbWb7A2djJ8hnZMrWnHo9F8ssv0OMErasDhftrfROTyqSDrw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "available-typed-arrays": "^1.0.7",
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "for-each": "^0.3.5",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/word-wrap": {
@@ -5562,6 +6937,45 @@
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/ws": {
+      "version": "8.18.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
+      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/yallist": {
       "version": "3.1.1",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build": "vite build",
     "preview": "vite preview",
     "server": "node server/index.js",
-    "lint": "eslint \"server/**/*.{js,jsx}\"",
+    "lint": "eslint \"server/**/*.{js,jsx}\" \"src/**/*.{js,jsx}\"",
     "test": "node --test --experimental-test-coverage"
   },
   "dependencies": {
@@ -22,11 +22,15 @@
     "recharts": "^2.7.2"
   },
   "devDependencies": {
+    "@testing-library/react": "^14.1.2",
+    "@testing-library/user-event": "^14.4.3",
     "@vitejs/plugin-react": "^4.0.0",
     "autoprefixer": "^10.4.15",
     "@eslint/js": "^9.11.1",
     "eslint": "^9.11.1",
     "globals": "^15.9.0",
+    "jsdom": "^24.0.0",
+    "prettier": "^3.2.5",
     "postcss": "^8.4.33",
     "supertest": "^7.0.0",
     "tailwindcss": "^3.3.5",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,444 +1,184 @@
-import React, { useState, useEffect, useMemo } from 'react';
-import { LineChart, Line, XAxis, YAxis, Tooltip, Legend, CartesianGrid, ResponsiveContainer } from 'recharts';
-import clsx from 'clsx';
+import { useCallback, useEffect, useMemo, useState } from "react";
+import DashboardTab from "./components/DashboardTab.jsx";
+import HoldingsTab from "./components/HoldingsTab.jsx";
+import PortfolioControls from "./components/PortfolioControls.jsx";
+import TabBar from "./components/TabBar.jsx";
+import TransactionsTab from "./components/TransactionsTab.jsx";
+import {
+  fetchPrices,
+  persistPortfolio,
+  retrievePortfolio,
+} from "./utils/api.js";
+import { buildHoldings, computeDashboardMetrics } from "./utils/holdings.js";
+import { buildRoiSeries } from "./utils/roi.js";
 
-// Utility to format currency
-const formatCurrency = (num) => {
-  return new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD' }).format(num);
-};
-
-// Base URL for API endpoints. This allows the frontend to run against a remote
-// Cloudflare Worker or local development server. When the environment variable
-// VITE_API_BASE is defined at build time, that value will be used; otherwise
-// it falls back to the deployed workers.dev endpoint. Adjust the fallback URL
-// to match your own Worker subdomain.
-const API_BASE = import.meta.env.VITE_API_BASE || 'https://portfolio-api.carlosortega77.workers.dev';
-
-// Fetch prices from backend; returns array [{date, close}]
-async function fetchPrices(symbol) {
-  // Prepend the API base to ensure requests go to the correct backend.
-  const res = await fetch(`${API_BASE}/api/prices/${symbol}?range=1y`);
-  const data = await res.json();
-  return data;
-}
+const DEFAULT_TAB = "Dashboard";
 
 export default function App() {
+  const [activeTab, setActiveTab] = useState(DEFAULT_TAB);
+  const [portfolioId, setPortfolioId] = useState("");
   const [transactions, setTransactions] = useState([]);
-  const [form, setForm] = useState({ date: '', ticker: '', type: 'BUY', amount: '', price: '' });
   const [signals, setSignals] = useState({});
-  const [portfolioId, setPortfolioId] = useState('');
+  const [currentPrices, setCurrentPrices] = useState({});
   const [roiData, setRoiData] = useState([]);
   const [loadingRoi, setLoadingRoi] = useState(false);
+  const [roiRefreshKey, setRoiRefreshKey] = useState(0);
 
-  // Derived holdings: group by ticker
-  const holdings = useMemo(() => {
-    const map = {};
-    transactions.forEach(tx => {
-      if (!map[tx.ticker]) {
-        map[tx.ticker] = { shares: 0, cost: 0, realised: 0, ticker: tx.ticker };
-      }
-      const h = map[tx.ticker];
-      if (tx.type === 'BUY') {
-        h.shares += tx.shares;
-        h.cost += Math.abs(tx.amount);
-      } else if (tx.type === 'SELL') {
-        // subtract shares; compute realised PnL using average cost
-        const avgCost = h.shares ? h.cost / h.shares : 0;
-        h.shares -= tx.shares; // tx.shares positive for sell
-        h.cost -= avgCost * tx.shares;
-        h.realised += tx.amount - avgCost * tx.shares;
-      } else if (tx.type === 'DIVIDEND' || tx.type === 'DEPOSIT' || tx.type === 'WITHDRAW') {
-        // dividends or deposits don't affect shares or cost
-      }
-    });
-    return Object.values(map);
-  }, [transactions]);
+  const holdings = useMemo(() => buildHoldings(transactions), [transactions]);
+  const metrics = useMemo(
+    () => computeDashboardMetrics(holdings, currentPrices),
+    [holdings, currentPrices],
+  );
 
-  // Compute current portfolio value and update holdings with price
-  const [currentPrices, setCurrentPrices] = useState({});
   useEffect(() => {
+    let cancelled = false;
+
     async function loadPrices() {
+      if (transactions.length === 0) {
+        setCurrentPrices({});
+        return;
+      }
+
       const uniqueTickers = [...new Set(transactions.map((tx) => tx.ticker))];
-      const newPrices = {};
-      await Promise.all(uniqueTickers.map(async (ticker) => {
-        const data = await fetchPrices(ticker);
-        const latest = data[data.length - 1];
-        if (latest) {
-          newPrices[ticker] = latest.close;
-        }
-      }));
-      setCurrentPrices(newPrices);
+      const priceEntries = await Promise.all(
+        uniqueTickers.map(async (ticker) => {
+          try {
+            const data = await fetchPrices(ticker);
+            const latest = data.at(-1);
+            return [ticker, latest?.close ?? 0];
+          } catch (error) {
+            console.error(error);
+            return [ticker, 0];
+          }
+        }),
+      );
+
+      if (!cancelled) {
+        setCurrentPrices(Object.fromEntries(priceEntries));
+      }
     }
-    if (transactions.length) {
-      loadPrices();
-    }
+
+    loadPrices();
+
+    return () => {
+      cancelled = true;
+    };
   }, [transactions]);
 
-  // Compute ROI vs SPY; create time series
   useEffect(() => {
-    async function computeRoi() {
+    let cancelled = false;
+
+    async function loadRoi() {
+      if (transactions.length === 0) {
+        setRoiData([]);
+        return;
+      }
+
       setLoadingRoi(true);
       try {
-        // Determine earliest date
-        if (transactions.length === 0) {
+        const series = await buildRoiSeries(transactions, fetchPrices);
+        if (!cancelled) {
+          setRoiData(series);
+        }
+      } catch (error) {
+        console.error(error);
+        if (!cancelled) {
           setRoiData([]);
+        }
+      } finally {
+        if (!cancelled) {
           setLoadingRoi(false);
-          return;
         }
-        const tickers = [...new Set(transactions.map(tx => tx.ticker))];
-        // Fetch price series for each ticker and SPY
-        const priceMap = {};
-        await Promise.all([...tickers, 'spy'].map(async sym => {
-          const data = await fetchPrices(sym);
-          priceMap[sym] = data;
-        }));
-        // Build a set of all dates present in SPY series (anchor)
-        const spyPrices = priceMap['spy'];
-        const dates = spyPrices.map(p => p.date);
-        // Build holdings per date: for each date compute shares per ticker (cumulative) and value
-        const roiSeries = [];
-        const initialPortfolioValueDate = transactions.reduce((min, tx) => {
-          const d = tx.date;
-          return !min || d < min ? d : min;
-        }, null);
-        // Precompute cumulative shares per ticker over time
-        const cumulative = {};
-        tickers.forEach(t => cumulative[t] = 0);
-        let initialValue = null;
-        for (const date of dates) {
-          // update cumulative shares based on transactions on this date
-          transactions
-            .filter(tx => tx.date === date)
-            .forEach(tx => {
-              if (tx.type === 'BUY') {
-                cumulative[tx.ticker] += tx.shares;
-              } else if (tx.type === 'SELL') {
-                cumulative[tx.ticker] -= tx.shares;
-              }
-            });
-          // compute portfolio value
-          let portValue = 0;
-          for (const t of tickers) {
-            // find price for this ticker on this date (fallback to previous close if missing)
-            const pSeries = priceMap[t];
-            let price = 0;
-            // find exact match or closest previous date
-            for (let i = 0; i < pSeries.length; i++) {
-              if (pSeries[i].date === date) {
-                price = pSeries[i].close;
-                break;
-              }
-              if (pSeries[i].date > date) {
-                price = pSeries[i > 0 ? i - 1 : i].close;
-                break;
-              }
-            }
-            portValue += cumulative[t] * price;
-          }
-          // compute ROI: (value - initial)/initial
-          if (initialValue === null) {
-            initialValue = portValue;
-          }
-          const portfolioRoi = initialValue === 0 ? 0 : ((portValue - initialValue) / initialValue) * 100;
-          // compute SPY ROI relative to initial SPY price
-          const spyPrice = spyPrices.find(p => p.date === date)?.close || spyPrices[0].close;
-          const initialSpyPrice = spyPrices[0].close;
-          const spyRoi = ((spyPrice - initialSpyPrice) / initialSpyPrice) * 100;
-          roiSeries.push({ date, portfolio: portfolioRoi, spy: spyRoi });
-        }
-        setRoiData(roiSeries);
-      } catch (err) {
-        console.error(err);
       }
-      setLoadingRoi(false);
     }
-    // recompute ROI when transactions change
-    computeRoi();
-  }, [transactions]);
 
-  // Handle form input changes
-  const updateForm = (field, value) => {
-    setForm((prev) => ({ ...prev, [field]: value }));
-  };
+    loadRoi();
 
-  // Add transaction
-  const addTransaction = (e) => {
-    e.preventDefault();
-    const { date, ticker, type, amount, price } = form;
-    if (!date || !ticker || !type || !amount || !price) return;
-    const amt = parseFloat(amount);
-    const prc = parseFloat(price);
-    const shares = Math.abs(amt) / prc;
-    const tx = {
-      date,
-      ticker: ticker.trim().toUpperCase(),
-      type,
-      amount: type === 'BUY' ? -Math.abs(amt) : Math.abs(amt),
-      price: prc,
-      shares,
+    return () => {
+      cancelled = true;
     };
-    setTransactions((prev) => [...prev, tx]);
-    setForm({ date: '', ticker: '', type: 'BUY', amount: '', price: '' });
-  };
+  }, [transactions, roiRefreshKey]);
 
-  // Save portfolio to server
-  const savePortfolio = async () => {
-    if (!portfolioId) return;
-    const body = {
-      transactions,
-      signals,
-    };
-    // Persist the portfolio to the backend using the API base.
-    await fetch(`${API_BASE}/api/portfolio/${portfolioId}`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(body),
-    });
-    alert('Portfolio saved!');
-  };
+  const handleAddTransaction = useCallback((transaction) => {
+    setTransactions((prev) => [...prev, transaction]);
+  }, []);
 
-  // Load portfolio
-  const loadPortfolio = async () => {
-    if (!portfolioId) return;
-    // Load the portfolio from the backend using the API base.
-    const res = await fetch(`${API_BASE}/api/portfolio/${portfolioId}`);
-    const data = await res.json();
-    if (data.transactions) setTransactions(data.transactions);
-    if (data.signals) setSignals(data.signals);
-  };
+  const handleSignalChange = useCallback((ticker, pct) => {
+    const pctValue = Number.parseFloat(pct);
+    if (!Number.isFinite(pctValue)) {
+      return;
+    }
 
-  // Update signal config for ticker
-  const updateSignal = (ticker, pct) => {
-    setSignals((prev) => ({ ...prev, [ticker]: { pct: parseFloat(pct) } }));
-  };
+    setSignals((prev) => ({ ...prev, [ticker]: { pct: pctValue } }));
+  }, []);
+
+  const handleSavePortfolio = useCallback(async () => {
+    const body = { transactions, signals };
+    await persistPortfolio(portfolioId, body);
+  }, [portfolioId, transactions, signals]);
+
+  const handleLoadPortfolio = useCallback(async () => {
+    const data = await retrievePortfolio(portfolioId);
+    if (Array.isArray(data.transactions)) {
+      setTransactions(data.transactions);
+    }
+    if (data.signals) {
+      setSignals(data.signals);
+    }
+  }, [portfolioId]);
+
+  const handleRefreshRoi = useCallback(() => {
+    setRoiRefreshKey((prev) => prev + 1);
+  }, []);
 
   return (
-    <div className="max-w-6xl mx-auto p-4">
-      <h1 className="text-3xl font-bold mb-4">Portfolio Manager</h1>
-      {/* Portfolio ID and Save/Load */}
-      <div className="flex gap-2 mb-4 items-end">
-        <div className="flex flex-col">
-          <label htmlFor="portfolioId" className="text-sm mb-1">
-            Portfolio ID
-          </label>
-          <input
-            id="portfolioId"
-            type="text"
-            className="border px-2 py-1 rounded w-40 dark:bg-gray-800 dark:border-gray-600"
-            value={portfolioId}
-            onChange={(e) => setPortfolioId(e.target.value)}
-          />
-        </div>
-        <button
-          onClick={savePortfolio}
-          className="bg-blue-600 hover:bg-blue-700 text-white px-3 py-1 rounded"
-        >
-          Save
-        </button>
-        <button
-          onClick={loadPortfolio}
-          className="bg-green-600 hover:bg-green-700 text-white px-3 py-1 rounded"
-        >
-          Load
-        </button>
-      </div>
+    <div className="min-h-screen bg-slate-100 px-4 py-6 text-slate-900 dark:bg-slate-950 dark:text-slate-100">
+      <div className="mx-auto flex max-w-6xl flex-col gap-6">
+        <header className="flex flex-col gap-2">
+          <h1 className="text-3xl font-bold tracking-tight text-slate-900 dark:text-white">
+            Portfolio Manager
+          </h1>
+          <p className="text-sm text-slate-600 dark:text-slate-400">
+            Monitor your assets, manage trades, and benchmark performance across
+            dedicated views.
+          </p>
+        </header>
 
-      {/* Transaction Form */}
-      <form onSubmit={addTransaction} className="bg-white dark:bg-gray-800 shadow-md rounded p-4 mb-6">
-        <h2 className="text-xl font-semibold mb-2">Add Transaction</h2>
-        <div className="grid grid-cols-6 gap-3 items-end">
-          <div className="flex flex-col">
-            <label className="text-sm mb-1">Date</label>
-            <input
-              type="date"
-              className="border px-2 py-1 rounded dark:bg-gray-700 dark:border-gray-600"
-              value={form.date}
-              onChange={(e) => updateForm('date', e.target.value)}
-              max={new Date().toISOString().split('T')[0]}
-            />
-          </div>
-          <div className="flex flex-col">
-            <label className="text-sm mb-1">Ticker</label>
-            <input
-              type="text"
-              className="border px-2 py-1 rounded dark:bg-gray-700 dark:border-gray-600"
-              value={form.ticker}
-              onChange={(e) => updateForm('ticker', e.target.value)}
-              placeholder="e.g. AAPL"
-            />
-          </div>
-          <div className="flex flex-col">
-            <label className="text-sm mb-1">Type</label>
-            <select
-              className="border px-2 py-1 rounded dark:bg-gray-700 dark:border-gray-600"
-              value={form.type}
-              onChange={(e) => updateForm('type', e.target.value)}
-            >
-              <option value="BUY">BUY</option>
-              <option value="SELL">SELL</option>
-              <option value="DIVIDEND">DIVIDEND</option>
-              <option value="DEPOSIT">DEPOSIT</option>
-              <option value="WITHDRAW">WITHDRAW</option>
-            </select>
-          </div>
-          <div className="flex flex-col">
-            <label className="text-sm mb-1">Amount (USD)</label>
-            <input
-              type="number"
-              step="0.01"
-              className="border px-2 py-1 rounded dark:bg-gray-700 dark:border-gray-600"
-              value={form.amount}
-              onChange={(e) => updateForm('amount', e.target.value)}
-            />
-          </div>
-          <div className="flex flex-col">
-            <label className="text-sm mb-1">Price (USD)</label>
-            <input
-              type="number"
-              step="0.01"
-              className="border px-2 py-1 rounded dark:bg-gray-700 dark:border-gray-600"
-              value={form.price}
-              onChange={(e) => updateForm('price', e.target.value)}
-            />
-          </div>
-          <div className="flex flex-col">
-            <span className="text-sm mb-1">Shares</span>
-            <span className="font-mono">
-              {form.amount && form.price ? (Math.abs(parseFloat(form.amount)) / parseFloat(form.price)).toFixed(4) : '—'}
-            </span>
-          </div>
-        </div>
-        <button
-          type="submit"
-          className="mt-4 bg-blue-600 hover:bg-blue-700 text-white px-3 py-1 rounded"
-        >
-          Add
-        </button>
-      </form>
+        <PortfolioControls
+          portfolioId={portfolioId}
+          onPortfolioIdChange={setPortfolioId}
+          onSave={handleSavePortfolio}
+          onLoad={handleLoadPortfolio}
+        />
 
-      {/* Holdings */}
-      <div className="bg-white dark:bg-gray-800 shadow-md rounded p-4 mb-6">
-        <h2 className="text-xl font-semibold mb-2">Holdings</h2>
-        {holdings.length === 0 ? (
-          <p>No holdings yet.</p>
-        ) : (
-          <table className="w-full text-sm">
-            <thead>
-              <tr className="border-b dark:border-gray-600 text-left">
-                <th className="py-1">Ticker</th>
-                <th className="py-1">Shares</th>
-                <th className="py-1">Avg Cost</th>
-                <th className="py-1">Current Price</th>
-                <th className="py-1">Value</th>
-                <th className="py-1">Unrealised PnL</th>
-                <th className="py-1">Realised PnL</th>
-              </tr>
-            </thead>
-            <tbody>
-              {holdings.map((h) => {
-                const price = currentPrices[h.ticker] ?? 0;
-                const avgCost = h.shares !== 0 ? h.cost / h.shares : 0;
-                const value = h.shares * price;
-                const unreal = value - h.cost;
-                return (
-                  <tr key={h.ticker} className="border-b dark:border-gray-700">
-                    <td className="py-1">{h.ticker}</td>
-                    <td className="py-1">{h.shares.toFixed(4)}</td>
-                    <td className="py-1">{formatCurrency(avgCost)}</td>
-                    <td className="py-1">{price ? formatCurrency(price) : '—'}</td>
-                    <td className="py-1">{formatCurrency(value)}</td>
-                    <td className="py-1">{formatCurrency(unreal)}</td>
-                    <td className="py-1">{formatCurrency(h.realised)}</td>
-                  </tr>
-                );
-              })}
-            </tbody>
-          </table>
-        )}
-      </div>
+        <TabBar activeTab={activeTab} onTabChange={setActiveTab} />
 
-      {/* Signals */}
-      <div className="bg-white dark:bg-gray-800 shadow-md rounded p-4 mb-6">
-        <h2 className="text-xl font-semibold mb-2">Signals</h2>
-        {holdings.length === 0 ? (
-          <p>Add transactions to configure signals.</p>
-        ) : (
-          <table className="w-full text-sm">
-            <thead>
-              <tr className="border-b dark:border-gray-600 text-left">
-                <th className="py-1">Ticker</th>
-                <th className="py-1">Pct Window (%)</th>
-                <th className="py-1">Last Price</th>
-                <th className="py-1">Buy Zone</th>
-                <th className="py-1">Upper Zone</th>
-                <th className="py-1">Signal</th>
-              </tr>
-            </thead>
-            <tbody>
-              {holdings.map((h) => {
-                const price = currentPrices[h.ticker] ?? 0;
-                const pct = signals[h.ticker]?.pct ?? 3;
-                const lower = price * (1 - pct / 100);
-                const upper = price * (1 + pct / 100);
-                let signal;
-                if (price < lower) signal = 'BUY zone';
-                else if (price > upper) signal = 'TRIM zone';
-                else signal = 'HOLD';
-                return (
-                  <tr key={h.ticker} className="border-b dark:border-gray-700">
-                    <td className="py-1">{h.ticker}</td>
-                    <td className="py-1">
-                      <input
-                        type="number"
-                        step="0.1"
-                        className="border px-1 py-0.5 w-16 rounded dark:bg-gray-700 dark:border-gray-600"
-                        value={pct}
-                        onChange={(e) => updateSignal(h.ticker, e.target.value)}
-                      />
-                    </td>
-                    <td className="py-1">{price ? formatCurrency(price) : '—'}</td>
-                    <td className="py-1">{price ? formatCurrency(lower) : '—'}</td>
-                    <td className="py-1">{price ? formatCurrency(upper) : '—'}</td>
-                    <td className="py-1">
-                      <span
-                        className={clsx(
-                          'px-2 py-0.5 rounded text-xs font-semibold',
-                          signal === 'BUY zone' && 'bg-green-600 text-white',
-                          signal === 'TRIM zone' && 'bg-red-600 text-white',
-                          signal === 'HOLD' && 'bg-yellow-500 text-white'
-                        )}
-                      >
-                        {signal}
-                      </span>
-                    </td>
-                  </tr>
-                );
-              })}
-            </tbody>
-          </table>
-        )}
-      </div>
+        <main className="pb-12">
+          {activeTab === "Dashboard" && (
+            <DashboardTab
+              metrics={metrics}
+              roiData={roiData}
+              loadingRoi={loadingRoi}
+              onRefreshRoi={handleRefreshRoi}
+            />
+          )}
 
-      {/* ROI Chart */}
-      <div className="bg-white dark:bg-gray-800 shadow-md rounded p-4 mb-6">
-        <h2 className="text-xl font-semibold mb-2">ROI vs SPY</h2>
-        {loadingRoi ? (
-          <p>Loading chart…</p>
-        ) : roiData.length === 0 ? (
-          <p>No data to display.</p>
-        ) : (
-          <ResponsiveContainer width="100%" height={300}>
-            <LineChart data={roiData} margin={{ top: 5, right: 20, left: 10, bottom: 5 }}>
-              <CartesianGrid strokeDasharray="3 3" />
-              <XAxis dataKey="date" tick={{ fontSize: 10 }} />
-              <YAxis domain={['auto', 'auto']} tickFormatter={(val) => `${val.toFixed(1)}%`} />
-              <Tooltip formatter={(value) => `${value.toFixed(2)}%`} />
-              <Legend />
-              <Line type="monotone" dataKey="portfolio" name="Portfolio ROI" stroke="#10b981" dot={false} />
-              <Line type="monotone" dataKey="spy" name="SPY %" stroke="#6366f1" dot={false} />
-            </LineChart>
-          </ResponsiveContainer>
-        )}
+          {activeTab === "Holdings" && (
+            <HoldingsTab
+              holdings={holdings}
+              currentPrices={currentPrices}
+              signals={signals}
+              onSignalChange={handleSignalChange}
+            />
+          )}
+
+          {activeTab === "Transactions" && (
+            <TransactionsTab
+              transactions={transactions}
+              onAddTransaction={handleAddTransaction}
+            />
+          )}
+        </main>
       </div>
     </div>
   );

--- a/src/__tests__/App.test.jsx
+++ b/src/__tests__/App.test.jsx
@@ -1,0 +1,135 @@
+import { afterEach, beforeEach, describe, it } from "node:test";
+import { strict as assert } from "node:assert";
+import { JSDOM } from "jsdom";
+import React from "react";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import App from "../App.jsx";
+
+let dom;
+
+beforeEach(() => {
+  dom = new JSDOM("<!doctype html><html><body></body></html>", {
+    url: "http://localhost/",
+  });
+  global.window = dom.window;
+  global.document = dom.window.document;
+  global.navigator = dom.window.navigator;
+  global.HTMLElement = dom.window.HTMLElement;
+  global.Node = dom.window.Node;
+  global.ResizeObserver = class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  };
+
+  const sampleSeries = [
+    { date: "2024-01-01", close: 100 },
+    { date: "2024-01-02", close: 110 },
+    { date: "2024-01-03", close: 120 },
+  ];
+
+  global.fetch = async (url, options = {}) => {
+    const href = typeof url === "string" ? url : url.url;
+    if (href.includes("/api/prices/")) {
+      const symbol = href.split("/").pop().split("?")[0];
+      return {
+        ok: true,
+        json: async () => {
+          if (symbol.toLowerCase() === "spy") {
+            return sampleSeries.map((point) => ({
+              ...point,
+              close: point.close + 5,
+            }));
+          }
+
+          return sampleSeries;
+        },
+      };
+    }
+
+    if (href.includes("/api/portfolio/") && options.method === "POST") {
+      return { ok: true, json: async () => ({}) };
+    }
+
+    if (href.includes("/api/portfolio/")) {
+      return {
+        ok: true,
+        json: async () => ({ transactions: [], signals: {} }),
+      };
+    }
+
+    throw new Error(`Unhandled fetch request: ${href}`);
+  };
+});
+
+afterEach(() => {
+  cleanup();
+  dom.window.close();
+  delete global.window;
+  delete global.document;
+  delete global.navigator;
+  delete global.HTMLElement;
+  delete global.Node;
+  delete global.ResizeObserver;
+  delete global.fetch;
+});
+
+describe("App tab navigation", () => {
+  it("renders dashboard by default and shows validation when saving without an ID", async () => {
+    render(<App />);
+    assert.ok(await screen.findByText("Portfolio Value"));
+
+    const saveButton = screen.getByRole("button", { name: /save portfolio/i });
+    await userEvent.click(saveButton);
+    assert.ok(screen.getByText("Set a portfolio ID first."));
+  });
+
+  it("allows switching between holdings and transactions views", async () => {
+    render(<App />);
+
+    const holdingsTab = screen.getByRole("button", { name: /holdings/i });
+    await userEvent.click(holdingsTab);
+    assert.ok(await screen.findByText("No holdings yet."));
+
+    const transactionsTab = screen.getByRole("button", {
+      name: /transactions/i,
+    });
+    await userEvent.click(transactionsTab);
+    assert.ok(await screen.findByText("Add Transaction"));
+  });
+
+  it("captures a transaction and surfaces it in the holdings view", async () => {
+    render(<App />);
+
+    const transactionsTab = screen.getByRole("button", {
+      name: /transactions/i,
+    });
+    await userEvent.click(transactionsTab);
+
+    const dateInput = screen.getByLabelText("Date");
+    fireEvent.input(dateInput, { target: { value: "2024-01-02" } });
+
+    const tickerInput = screen.getByLabelText("Ticker");
+    await userEvent.type(tickerInput, "aapl");
+
+    const amountInput = screen.getByLabelText("Amount (USD)");
+    await userEvent.type(amountInput, "1000");
+
+    const priceInput = screen.getByLabelText("Price (USD)");
+    await userEvent.type(priceInput, "100");
+
+    const submitButton = screen.getByRole("button", {
+      name: /add transaction/i,
+    });
+    await userEvent.click(submitButton);
+
+    assert.ok(await screen.findByText("1.0000"));
+
+    const holdingsTab = screen.getByRole("button", { name: /holdings/i });
+    await userEvent.click(holdingsTab);
+
+    assert.ok(await screen.findByText("AAPL"));
+    assert.ok(await screen.findByText("$1,000.00"));
+  });
+});

--- a/src/__tests__/format.test.js
+++ b/src/__tests__/format.test.js
@@ -1,0 +1,17 @@
+import { describe, it } from "node:test";
+import { strict as assert } from "node:assert";
+import { formatCurrency, formatPercent } from "../utils/format.js";
+
+describe("format utilities", () => {
+  it("formats currency with fallback for invalid inputs", () => {
+    assert.equal(formatCurrency(1234.567), "$1,234.57");
+    assert.equal(formatCurrency(null), "—");
+    assert.equal(formatCurrency(Number.NaN), "—");
+  });
+
+  it("formats percentage values with precision control", () => {
+    assert.equal(formatPercent(12.3456), "12.35%");
+    assert.equal(formatPercent(9.1, 1), "9.1%");
+    assert.equal(formatPercent(undefined), "—");
+  });
+});

--- a/src/__tests__/holdings.test.js
+++ b/src/__tests__/holdings.test.js
@@ -1,0 +1,60 @@
+import { describe, it } from "node:test";
+import { strict as assert } from "node:assert";
+import {
+  buildHoldings,
+  computeDashboardMetrics,
+  deriveHoldingStats,
+  deriveSignalRow,
+} from "../utils/holdings.js";
+
+const transactions = [
+  { ticker: "AAPL", type: "BUY", shares: 5, amount: -500 },
+  { ticker: "AAPL", type: "BUY", shares: 5, amount: -600 },
+  { ticker: "AAPL", type: "SELL", shares: 3, amount: 450 },
+  { ticker: "MSFT", type: "BUY", shares: 2, amount: -400 },
+];
+
+describe("holdings utilities", () => {
+  it("builds aggregate holdings with realised gains", () => {
+    const holdings = buildHoldings(transactions);
+    assert.equal(holdings.length, 2);
+
+    const apple = holdings.find((item) => item.ticker === "AAPL");
+    assert.ok(apple);
+    assert.equal(Number(apple.shares.toFixed(2)), 7);
+    assert.ok(apple.realised > 0);
+  });
+
+  it("derives holding stats and signal rows", () => {
+    const holdings = buildHoldings(transactions);
+    const apple = holdings.find((item) => item.ticker === "AAPL");
+    const stats = deriveHoldingStats(apple, 130);
+
+    assert.equal(stats.value, 910);
+    assert.equal(stats.avgCostLabel, "$110.00");
+
+    const signal = deriveSignalRow(apple, 130, 5);
+    assert.equal(signal.lower, "$123.50");
+    assert.equal(signal.signal, "HOLD");
+  });
+
+  it("computes dashboard metrics", () => {
+    const holdings = buildHoldings(transactions);
+    const metrics = computeDashboardMetrics(holdings, { AAPL: 130, MSFT: 210 });
+
+    assert.equal(Math.round(metrics.totalValue), 1330);
+    assert.equal(metrics.holdingsCount, 2);
+  });
+
+  it("handles missing tickers and unavailable prices gracefully", () => {
+    const holdings = buildHoldings([
+      { ticker: "", type: "BUY", shares: 1, amount: -10 },
+      { ticker: "NFLX", type: "BUY", shares: 2, amount: -200 },
+    ]);
+
+    assert.equal(holdings.length, 1);
+    const signal = deriveSignalRow(holdings[0], undefined, 4);
+    assert.equal(signal.signal, "NO DATA");
+    assert.equal(signal.price, "—");
+  });
+});

--- a/src/__tests__/roi.test.js
+++ b/src/__tests__/roi.test.js
@@ -1,0 +1,80 @@
+import { describe, it } from "node:test";
+import { strict as assert } from "node:assert";
+import { buildRoiSeries } from "../utils/roi.js";
+
+const transactions = [
+  { date: "2024-01-01", ticker: "AAPL", type: "BUY", shares: 1, amount: -100 },
+  { date: "2024-01-02", ticker: "AAPL", type: "BUY", shares: 1, amount: -110 },
+];
+
+const priceMap = {
+  AAPL: [
+    { date: "2024-01-01", close: 100 },
+    { date: "2024-01-02", close: 120 },
+    { date: "2024-01-03", close: 140 },
+  ],
+  SPY: [
+    { date: "2024-01-01", close: 200 },
+    { date: "2024-01-02", close: 210 },
+    { date: "2024-01-03", close: 220 },
+  ],
+};
+
+describe("ROI utilities", () => {
+  it("builds ROI series relative to SPY", async () => {
+    const fetcher = async (symbol) => priceMap[symbol.toUpperCase()];
+    const series = await buildRoiSeries(transactions, fetcher);
+
+    assert.equal(series.length, 3);
+    assert.equal(series[0].portfolio, 0);
+    assert.ok(series[2].portfolio > 0);
+    assert.equal(series[0].spy, 0);
+  });
+
+  it("returns an empty series when transactions are missing", async () => {
+    const fetcher = async () => priceMap.AAPL;
+    const series = await buildRoiSeries([], fetcher);
+    assert.deepEqual(series, []);
+  });
+
+  it("returns an empty series when SPY data is unavailable", async () => {
+    const fetcher = async (symbol) => (symbol === "spy" ? [] : priceMap.AAPL);
+    const series = await buildRoiSeries(transactions, fetcher);
+    assert.deepEqual(series, []);
+  });
+
+  it("falls back to the previous close when a ticker lacks data for a date", async () => {
+    const extendedTransactions = [
+      ...transactions,
+      {
+        date: "2024-01-03",
+        ticker: "AAPL",
+        type: "SELL",
+        shares: 1,
+        amount: 130,
+      },
+    ];
+    const fetcher = async (symbol) => {
+      if (symbol.toUpperCase() === "AAPL") {
+        return [
+          { date: "2024-01-01", close: 100 },
+          { date: "2024-01-03", close: 140 },
+        ];
+      }
+
+      return priceMap.SPY;
+    };
+
+    const series = await buildRoiSeries(extendedTransactions, fetcher);
+    assert.equal(series.length, 3);
+    assert.ok(series[1].portfolio >= 0);
+  });
+
+  it("uses zero pricing when a ticker series is empty", async () => {
+    const fetcher = async (symbol) =>
+      symbol.toUpperCase() === "AAPL" ? [] : priceMap.SPY;
+    const series = await buildRoiSeries(transactions, fetcher);
+    assert.equal(series.length, 3);
+    assert.equal(series[1].portfolio, 0);
+  });
+});

--- a/src/components/DashboardTab.jsx
+++ b/src/components/DashboardTab.jsx
@@ -1,0 +1,153 @@
+import {
+  LineChart,
+  Line,
+  XAxis,
+  YAxis,
+  Tooltip,
+  Legend,
+  CartesianGrid,
+  ResponsiveContainer,
+} from "recharts";
+import { formatCurrency, formatPercent } from "../utils/format.js";
+
+function MetricCard({ label, value, description }) {
+  return (
+    <div className="rounded-lg border border-slate-200 bg-white p-4 shadow-sm dark:border-slate-800 dark:bg-slate-900">
+      <p className="text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
+        {label}
+      </p>
+      <p className="mt-2 text-2xl font-bold text-slate-900 dark:text-slate-100">
+        {value}
+      </p>
+      {description && (
+        <p className="mt-1 text-sm text-slate-500 dark:text-slate-400">
+          {description}
+        </p>
+      )}
+    </div>
+  );
+}
+
+function QuickActions({ onRefresh }) {
+  return (
+    <div className="rounded-lg border border-slate-200 bg-white p-4 shadow-sm dark:border-slate-800 dark:bg-slate-900">
+      <h3 className="text-sm font-semibold text-slate-600 dark:text-slate-300">
+        Quick Actions
+      </h3>
+      <div className="mt-3 flex flex-wrap gap-3">
+        <button
+          type="button"
+          onClick={onRefresh}
+          className="rounded-md bg-indigo-600 px-3 py-2 text-sm font-semibold text-white shadow hover:bg-indigo-700 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-500"
+        >
+          Refresh ROI
+        </button>
+        <a
+          className="rounded-md border border-slate-200 px-3 py-2 text-sm font-semibold text-slate-600 shadow-sm transition hover:border-indigo-400 hover:text-indigo-600 dark:border-slate-700 dark:text-slate-300 dark:hover:border-indigo-400 dark:hover:text-indigo-300"
+          href="https://www.investopedia.com/terms/p/portfolio.asp"
+          target="_blank"
+          rel="noreferrer"
+        >
+          Portfolio Tips
+        </a>
+      </div>
+    </div>
+  );
+}
+
+function RoiChart({ data, loading }) {
+  return (
+    <div className="rounded-lg border border-slate-200 bg-white p-4 shadow-sm dark:border-slate-800 dark:bg-slate-900">
+      <div className="flex items-center justify-between">
+        <h3 className="text-sm font-semibold text-slate-600 dark:text-slate-300">
+          ROI vs SPY
+        </h3>
+        {loading && (
+          <span className="text-xs font-medium text-indigo-500">Loading…</span>
+        )}
+      </div>
+      <div className="mt-4 h-72 w-full">
+        {data.length === 0 ? (
+          <p className="text-sm text-slate-500 dark:text-slate-400">
+            Add transactions to see comparative performance.
+          </p>
+        ) : (
+          <ResponsiveContainer width="100%" height="100%">
+            <LineChart
+              data={data}
+              margin={{ top: 5, right: 20, left: 10, bottom: 5 }}
+            >
+              <CartesianGrid
+                strokeDasharray="3 3"
+                stroke="#cbd5f5"
+                opacity={0.5}
+              />
+              <XAxis dataKey="date" tick={{ fontSize: 10 }} stroke="#94a3b8" />
+              <YAxis
+                tickFormatter={(value) => formatPercent(value, 1)}
+                stroke="#94a3b8"
+              />
+              <Tooltip formatter={(value) => formatPercent(Number(value))} />
+              <Legend />
+              <Line
+                type="monotone"
+                dataKey="portfolio"
+                name="Portfolio ROI"
+                stroke="#10b981"
+                dot={false}
+                strokeWidth={2}
+              />
+              <Line
+                type="monotone"
+                dataKey="spy"
+                name="SPY %"
+                stroke="#6366f1"
+                dot={false}
+                strokeWidth={2}
+              />
+            </LineChart>
+          </ResponsiveContainer>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export default function DashboardTab({
+  metrics,
+  roiData,
+  loadingRoi,
+  onRefreshRoi,
+}) {
+  const returnPct =
+    metrics.totalCost === 0
+      ? 0
+      : (metrics.totalValue - metrics.totalCost) / metrics.totalCost;
+
+  return (
+    <div className="space-y-6">
+      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+        <MetricCard
+          label="Portfolio Value"
+          value={formatCurrency(metrics.totalValue)}
+        />
+        <MetricCard
+          label="Invested Capital"
+          value={formatCurrency(metrics.totalCost)}
+        />
+        <MetricCard
+          label="Unrealised PnL"
+          value={formatCurrency(metrics.totalUnrealised)}
+          description={`Realised: ${formatCurrency(metrics.totalRealised)}`}
+        />
+        <MetricCard
+          label="Holdings"
+          value={metrics.holdingsCount}
+          description={`Return ${formatPercent(returnPct * 100, 1)}`}
+        />
+      </div>
+      <QuickActions onRefresh={onRefreshRoi} />
+      <RoiChart data={roiData} loading={loadingRoi} />
+    </div>
+  );
+}

--- a/src/components/HoldingsTab.jsx
+++ b/src/components/HoldingsTab.jsx
@@ -1,0 +1,156 @@
+import clsx from "clsx";
+import { deriveHoldingStats, deriveSignalRow } from "../utils/holdings.js";
+
+function HoldingsTable({ holdings, currentPrices }) {
+  if (holdings.length === 0) {
+    return (
+      <p className="text-sm text-slate-500 dark:text-slate-400">
+        No holdings yet.
+      </p>
+    );
+  }
+
+  return (
+    <div className="overflow-x-auto">
+      <table className="min-w-full divide-y divide-slate-200 text-sm dark:divide-slate-700">
+        <thead className="bg-slate-50 dark:bg-slate-800/60">
+          <tr className="text-left text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-300">
+            <th className="px-3 py-2">Ticker</th>
+            <th className="px-3 py-2">Shares</th>
+            <th className="px-3 py-2">Avg Cost</th>
+            <th className="px-3 py-2">Current Price</th>
+            <th className="px-3 py-2">Value</th>
+            <th className="px-3 py-2">Unrealised PnL</th>
+            <th className="px-3 py-2">Realised PnL</th>
+          </tr>
+        </thead>
+        <tbody className="divide-y divide-slate-200 dark:divide-slate-800">
+          {holdings.map((holding) => {
+            const enriched = deriveHoldingStats(
+              holding,
+              currentPrices[holding.ticker],
+            );
+            return (
+              <tr key={holding.ticker} className="bg-white dark:bg-slate-900">
+                <td className="px-3 py-2 font-semibold">{holding.ticker}</td>
+                <td className="px-3 py-2">{holding.shares.toFixed(4)}</td>
+                <td className="px-3 py-2">{enriched.avgCostLabel}</td>
+                <td className="px-3 py-2">{enriched.priceLabel}</td>
+                <td className="px-3 py-2">{enriched.valueLabel}</td>
+                <td className="px-3 py-2">{enriched.unrealisedLabel}</td>
+                <td className="px-3 py-2">{enriched.realisedLabel ?? "—"}</td>
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+function SignalsTable({ holdings, currentPrices, signals, onSignalChange }) {
+  if (holdings.length === 0) {
+    return (
+      <p className="text-sm text-slate-500 dark:text-slate-400">
+        Add transactions to configure signals.
+      </p>
+    );
+  }
+
+  return (
+    <div className="overflow-x-auto">
+      <table className="min-w-full divide-y divide-slate-200 text-sm dark:divide-slate-700">
+        <thead className="bg-slate-50 dark:bg-slate-800/60">
+          <tr className="text-left text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-300">
+            <th className="px-3 py-2">Ticker</th>
+            <th className="px-3 py-2">Pct Window (%)</th>
+            <th className="px-3 py-2">Last Price</th>
+            <th className="px-3 py-2">Lower Bound</th>
+            <th className="px-3 py-2">Upper Bound</th>
+            <th className="px-3 py-2">Signal</th>
+          </tr>
+        </thead>
+        <tbody className="divide-y divide-slate-200 dark:divide-slate-800">
+          {holdings.map((holding) => {
+            const pctWindow = signals[holding.ticker]?.pct ?? 3;
+            const row = deriveSignalRow(
+              holding,
+              currentPrices[holding.ticker],
+              pctWindow,
+            );
+            return (
+              <tr key={holding.ticker} className="bg-white dark:bg-slate-900">
+                <td className="px-3 py-2 font-semibold">{holding.ticker}</td>
+                <td className="px-3 py-2">
+                  <input
+                    type="number"
+                    step="0.1"
+                    min="0"
+                    className="w-20 rounded-md border border-slate-300 px-2 py-1 text-sm focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-200 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-100"
+                    value={pctWindow}
+                    onChange={(event) =>
+                      onSignalChange(holding.ticker, event.target.value)
+                    }
+                  />
+                </td>
+                <td className="px-3 py-2">{row.price}</td>
+                <td className="px-3 py-2">{row.lower}</td>
+                <td className="px-3 py-2">{row.upper}</td>
+                <td className="px-3 py-2">
+                  <span
+                    className={clsx(
+                      "rounded-full px-3 py-1 text-xs font-semibold uppercase tracking-wide",
+                      row.signal === "BUY zone" &&
+                        "bg-emerald-100 text-emerald-700 dark:bg-emerald-500/20 dark:text-emerald-200",
+                      row.signal === "TRIM zone" &&
+                        "bg-rose-100 text-rose-700 dark:bg-rose-500/20 dark:text-rose-200",
+                      row.signal === "HOLD" &&
+                        "bg-amber-100 text-amber-700 dark:bg-amber-500/20 dark:text-amber-200",
+                      row.signal === "NO DATA" &&
+                        "bg-slate-100 text-slate-600 dark:bg-slate-700 dark:text-slate-300",
+                    )}
+                  >
+                    {row.signal}
+                  </span>
+                </td>
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+export default function HoldingsTab({
+  holdings,
+  currentPrices,
+  signals,
+  onSignalChange,
+}) {
+  return (
+    <div className="space-y-6">
+      <div className="rounded-xl border border-slate-200 bg-white p-4 shadow dark:border-slate-800 dark:bg-slate-900">
+        <h2 className="text-lg font-semibold text-slate-700 dark:text-slate-200">
+          Holdings
+        </h2>
+        <div className="mt-4">
+          <HoldingsTable holdings={holdings} currentPrices={currentPrices} />
+        </div>
+      </div>
+      <div className="rounded-xl border border-slate-200 bg-white p-4 shadow dark:border-slate-800 dark:bg-slate-900">
+        <h2 className="text-lg font-semibold text-slate-700 dark:text-slate-200">
+          Signals
+        </h2>
+        <div className="mt-4">
+          <SignalsTable
+            holdings={holdings}
+            currentPrices={currentPrices}
+            signals={signals}
+            onSignalChange={onSignalChange}
+          />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/PortfolioControls.jsx
+++ b/src/components/PortfolioControls.jsx
@@ -1,0 +1,77 @@
+import { useState } from "react";
+
+export default function PortfolioControls({
+  portfolioId,
+  onPortfolioIdChange,
+  onSave,
+  onLoad,
+}) {
+  const [status, setStatus] = useState(null);
+
+  async function handle(action) {
+    if (!portfolioId) {
+      setStatus({ type: "error", message: "Set a portfolio ID first." });
+      return;
+    }
+
+    try {
+      await action();
+      setStatus({
+        type: "success",
+        message: "Operation completed successfully.",
+      });
+    } catch (error) {
+      setStatus({ type: "error", message: error.message });
+    }
+  }
+
+  return (
+    <div className="rounded-xl bg-white p-4 shadow dark:bg-slate-900">
+      <div className="flex flex-wrap items-end gap-4">
+        <div className="flex flex-col">
+          <label
+            htmlFor="portfolioId"
+            className="text-sm font-medium text-slate-600 dark:text-slate-300"
+          >
+            Portfolio ID
+          </label>
+          <input
+            id="portfolioId"
+            type="text"
+            className="mt-1 w-48 rounded-md border border-slate-300 px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-200 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-100"
+            value={portfolioId}
+            onChange={(event) => onPortfolioIdChange(event.target.value)}
+            placeholder="e.g. demo-portfolio"
+          />
+        </div>
+        <div className="flex gap-3">
+          <button
+            type="button"
+            onClick={() => handle(onSave)}
+            className="rounded-md bg-indigo-600 px-4 py-2 text-sm font-semibold text-white shadow hover:bg-indigo-700 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-500"
+          >
+            Save Portfolio
+          </button>
+          <button
+            type="button"
+            onClick={() => handle(onLoad)}
+            className="rounded-md bg-emerald-600 px-4 py-2 text-sm font-semibold text-white shadow hover:bg-emerald-700 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-emerald-500"
+          >
+            Load Portfolio
+          </button>
+        </div>
+      </div>
+      {status && (
+        <p
+          className={`mt-3 text-sm ${
+            status.type === "success"
+              ? "text-emerald-600 dark:text-emerald-400"
+              : "text-rose-600 dark:text-rose-400"
+          }`}
+        >
+          {status.message}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/src/components/TabBar.jsx
+++ b/src/components/TabBar.jsx
@@ -1,0 +1,22 @@
+import TabButton from "./TabButton.jsx";
+
+const tabs = ["Dashboard", "Holdings", "Transactions"];
+
+export default function TabBar({ activeTab, onTabChange }) {
+  return (
+    <div className="mb-6 rounded-xl bg-white/80 p-1 shadow dark:bg-slate-900/80">
+      <div className="flex gap-2">
+        {tabs.map((tab) => (
+          <TabButton
+            key={tab}
+            label={tab}
+            isActive={activeTab === tab}
+            onClick={() => onTabChange(tab)}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export { tabs as TAB_OPTIONS };

--- a/src/components/TabButton.jsx
+++ b/src/components/TabButton.jsx
@@ -1,0 +1,20 @@
+import clsx from "clsx";
+
+export default function TabButton({ label, isActive, onClick }) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={clsx(
+        "flex-1 rounded-md px-4 py-2 text-sm font-semibold transition-colors",
+        "focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-500",
+        isActive
+          ? "bg-indigo-600 text-white shadow"
+          : "bg-slate-100 text-slate-600 hover:bg-slate-200 dark:bg-slate-800 dark:text-slate-300 dark:hover:bg-slate-700",
+      )}
+      aria-pressed={isActive}
+    >
+      {label}
+    </button>
+  );
+}

--- a/src/components/TransactionsTab.jsx
+++ b/src/components/TransactionsTab.jsx
@@ -1,0 +1,194 @@
+import { useState } from "react";
+import { formatCurrency } from "../utils/format.js";
+
+const defaultForm = {
+  date: "",
+  ticker: "",
+  type: "BUY",
+  amount: "",
+  price: "",
+};
+
+function TransactionsTable({ transactions }) {
+  if (transactions.length === 0) {
+    return (
+      <p className="text-sm text-slate-500 dark:text-slate-400">
+        No transactions recorded yet.
+      </p>
+    );
+  }
+
+  return (
+    <div className="overflow-x-auto">
+      <table className="min-w-full divide-y divide-slate-200 text-sm dark:divide-slate-700">
+        <thead className="bg-slate-50 dark:bg-slate-800/60">
+          <tr className="text-left text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-300">
+            <th className="px-3 py-2">Date</th>
+            <th className="px-3 py-2">Ticker</th>
+            <th className="px-3 py-2">Type</th>
+            <th className="px-3 py-2">Amount</th>
+            <th className="px-3 py-2">Price</th>
+            <th className="px-3 py-2">Shares</th>
+          </tr>
+        </thead>
+        <tbody className="divide-y divide-slate-200 dark:divide-slate-800">
+          {transactions.map((transaction, index) => (
+            <tr
+              key={`${transaction.ticker}-${transaction.date}-${index}`}
+              className="bg-white dark:bg-slate-900"
+            >
+              <td className="px-3 py-2">{transaction.date}</td>
+              <td className="px-3 py-2 font-semibold">{transaction.ticker}</td>
+              <td className="px-3 py-2">{transaction.type}</td>
+              <td className="px-3 py-2">
+                {formatCurrency(transaction.amount)}
+              </td>
+              <td className="px-3 py-2">{formatCurrency(transaction.price)}</td>
+              <td className="px-3 py-2">{transaction.shares.toFixed(4)}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+export default function TransactionsTab({ onAddTransaction, transactions }) {
+  const [form, setForm] = useState(defaultForm);
+  const [error, setError] = useState(null);
+
+  function updateForm(field, value) {
+    setForm((prev) => ({ ...prev, [field]: value }));
+  }
+
+  function handleSubmit(event) {
+    event.preventDefault();
+    const { date, ticker, type, amount, price } = form;
+    if (!date || !ticker || !type || !amount || !price) {
+      setError("Please fill in all fields.");
+      return;
+    }
+
+    const amountValue = Number.parseFloat(amount);
+    const priceValue = Number.parseFloat(price);
+    if (
+      !Number.isFinite(amountValue) ||
+      !Number.isFinite(priceValue) ||
+      priceValue === 0
+    ) {
+      setError("Amount and price must be valid numbers.");
+      return;
+    }
+
+    const shares = Math.abs(amountValue) / priceValue;
+    const payload = {
+      date,
+      ticker: ticker.trim().toUpperCase(),
+      type,
+      amount: type === "BUY" ? -Math.abs(amountValue) : Math.abs(amountValue),
+      price: priceValue,
+      shares,
+    };
+
+    onAddTransaction(payload);
+    setForm(defaultForm);
+    setError(null);
+  }
+
+  const computedShares =
+    form.amount && form.price && Number.isFinite(Number.parseFloat(form.price))
+      ? Math.abs(Number.parseFloat(form.amount || 0)) /
+        Number.parseFloat(form.price || 1)
+      : null;
+
+  return (
+    <div className="space-y-6">
+      <div className="rounded-xl border border-slate-200 bg-white p-4 shadow dark:border-slate-800 dark:bg-slate-900">
+        <h2 className="text-lg font-semibold text-slate-700 dark:text-slate-200">
+          Add Transaction
+        </h2>
+        <form onSubmit={handleSubmit} className="mt-4 space-y-4" noValidate>
+          <div className="grid gap-4 md:grid-cols-6">
+            <label className="flex flex-col text-sm font-medium text-slate-600 dark:text-slate-300">
+              Date
+              <input
+                type="date"
+                value={form.date}
+                max={new Date().toISOString().split("T")[0]}
+                onChange={(event) => updateForm("date", event.target.value)}
+                className="mt-1 rounded-md border border-slate-300 px-3 py-2 text-sm focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-200 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-100"
+              />
+            </label>
+            <label className="flex flex-col text-sm font-medium text-slate-600 dark:text-slate-300">
+              Ticker
+              <input
+                type="text"
+                value={form.ticker}
+                onChange={(event) => updateForm("ticker", event.target.value)}
+                placeholder="e.g. AAPL"
+                className="mt-1 rounded-md border border-slate-300 px-3 py-2 text-sm uppercase focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-200 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-100"
+              />
+            </label>
+            <label className="flex flex-col text-sm font-medium text-slate-600 dark:text-slate-300">
+              Type
+              <select
+                value={form.type}
+                onChange={(event) => updateForm("type", event.target.value)}
+                className="mt-1 rounded-md border border-slate-300 px-3 py-2 text-sm focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-200 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-100"
+              >
+                <option value="BUY">BUY</option>
+                <option value="SELL">SELL</option>
+                <option value="DIVIDEND">DIVIDEND</option>
+                <option value="DEPOSIT">DEPOSIT</option>
+                <option value="WITHDRAW">WITHDRAW</option>
+              </select>
+            </label>
+            <label className="flex flex-col text-sm font-medium text-slate-600 dark:text-slate-300">
+              Amount (USD)
+              <input
+                type="number"
+                step="0.01"
+                value={form.amount}
+                onChange={(event) => updateForm("amount", event.target.value)}
+                className="mt-1 rounded-md border border-slate-300 px-3 py-2 text-sm focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-200 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-100"
+              />
+            </label>
+            <label className="flex flex-col text-sm font-medium text-slate-600 dark:text-slate-300">
+              Price (USD)
+              <input
+                type="number"
+                step="0.01"
+                value={form.price}
+                onChange={(event) => updateForm("price", event.target.value)}
+                className="mt-1 rounded-md border border-slate-300 px-3 py-2 text-sm focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-200 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-100"
+              />
+            </label>
+            <div className="flex flex-col text-sm font-medium text-slate-600 dark:text-slate-300">
+              Shares
+              <span className="mt-1 rounded-md border border-dashed border-slate-300 px-3 py-2 font-mono text-sm text-slate-600 dark:border-slate-700 dark:text-slate-300">
+                {computedShares ? computedShares.toFixed(4) : "—"}
+              </span>
+            </div>
+          </div>
+          {error && (
+            <p className="text-sm text-rose-600 dark:text-rose-400">{error}</p>
+          )}
+          <button
+            type="submit"
+            className="rounded-md bg-indigo-600 px-4 py-2 text-sm font-semibold text-white shadow hover:bg-indigo-700 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-500"
+          >
+            Add Transaction
+          </button>
+        </form>
+      </div>
+      <div className="rounded-xl border border-slate-200 bg-white p-4 shadow dark:border-slate-800 dark:bg-slate-900">
+        <h2 className="text-lg font-semibold text-slate-700 dark:text-slate-200">
+          Recent Activity
+        </h2>
+        <div className="mt-4">
+          <TransactionsTable transactions={transactions} />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/index.css
+++ b/src/index.css
@@ -3,6 +3,18 @@
 @tailwind utilities;
 
 /* Custom global styles */
+:root {
+  color-scheme: light dark;
+}
+
 body {
-  @apply font-sans;
+  @apply min-h-screen bg-slate-100 font-sans text-slate-900 antialiased dark:bg-slate-950 dark:text-slate-100;
+}
+
+#root {
+  @apply min-h-screen;
+}
+
+table {
+  @apply w-full;
 }

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,10 +1,10 @@
-import React from 'react';
-import ReactDOM from 'react-dom/client';
-import App from './App.jsx';
-import './index.css';
+import React from "react";
+import ReactDOM from "react-dom/client";
+import App from "./App.jsx";
+import "./index.css";
 
 // Tailwind base styles and CSS resets are imported via index.css
-ReactDOM.createRoot(document.getElementById('root')).render(
+ReactDOM.createRoot(document.getElementById("root")).render(
   <React.StrictMode>
     <App />
   </React.StrictMode>,

--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -1,0 +1,37 @@
+export const API_BASE =
+  import.meta.env.VITE_API_BASE ||
+  "https://portfolio-api.carlosortega77.workers.dev";
+
+export async function fetchPrices(symbol, range = "1y") {
+  const response = await fetch(
+    `${API_BASE}/api/prices/${symbol}?range=${range}`,
+  );
+  if (!response.ok) {
+    throw new Error(`Failed to fetch prices for ${symbol}`);
+  }
+
+  return response.json();
+}
+
+export async function persistPortfolio(portfolioId, body) {
+  const response = await fetch(`${API_BASE}/api/portfolio/${portfolioId}`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+
+  if (!response.ok) {
+    throw new Error(`Unable to save portfolio ${portfolioId}`);
+  }
+
+  return response.json().catch(() => ({}));
+}
+
+export async function retrievePortfolio(portfolioId) {
+  const response = await fetch(`${API_BASE}/api/portfolio/${portfolioId}`);
+  if (!response.ok) {
+    throw new Error(`Unable to load portfolio ${portfolioId}`);
+  }
+
+  return response.json();
+}

--- a/src/utils/format.js
+++ b/src/utils/format.js
@@ -1,0 +1,19 @@
+export function formatCurrency(value) {
+  if (Number.isNaN(value) || value === undefined || value === null) {
+    return "—";
+  }
+
+  return new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: "USD",
+    maximumFractionDigits: 2,
+  }).format(value);
+}
+
+export function formatPercent(value, fractionDigits = 2) {
+  if (Number.isNaN(value) || value === undefined || value === null) {
+    return "—";
+  }
+
+  return `${value.toFixed(fractionDigits)}%`;
+}

--- a/src/utils/holdings.js
+++ b/src/utils/holdings.js
@@ -1,0 +1,99 @@
+import { formatCurrency } from "./format.js";
+
+export function buildHoldings(transactions) {
+  const map = new Map();
+
+  transactions.forEach((tx) => {
+    const ticker = tx.ticker?.trim().toUpperCase();
+    if (!ticker) {
+      return;
+    }
+
+    if (!map.has(ticker)) {
+      map.set(ticker, { ticker, shares: 0, cost: 0, realised: 0 });
+    }
+
+    const holding = map.get(ticker);
+    if (tx.type === "BUY") {
+      holding.shares += tx.shares;
+      holding.cost += Math.abs(tx.amount);
+    } else if (tx.type === "SELL") {
+      const avgCost = holding.shares ? holding.cost / holding.shares : 0;
+      holding.shares -= tx.shares;
+      holding.cost -= avgCost * tx.shares;
+      holding.realised += tx.amount - avgCost * tx.shares;
+    }
+  });
+
+  return Array.from(map.values());
+}
+
+export function deriveHoldingStats(holding, currentPrice) {
+  const avgCost = holding.shares ? holding.cost / holding.shares : 0;
+  const value = holding.shares * (currentPrice ?? 0);
+  const unrealised = value - holding.cost;
+
+  return {
+    ...holding,
+    avgCost,
+    value,
+    unrealised,
+    avgCostLabel: formatCurrency(avgCost),
+    valueLabel: formatCurrency(value),
+    unrealisedLabel: formatCurrency(unrealised),
+    priceLabel: formatCurrency(currentPrice),
+    realisedLabel: formatCurrency(holding.realised),
+  };
+}
+
+export function deriveSignalRow(holding, currentPrice, pctWindow) {
+  if (!currentPrice) {
+    return {
+      ticker: holding.ticker,
+      pctWindow,
+      price: "—",
+      lower: "—",
+      upper: "—",
+      signal: "NO DATA",
+    };
+  }
+
+  const lower = currentPrice * (1 - pctWindow / 100);
+  const upper = currentPrice * (1 + pctWindow / 100);
+  let signal = "HOLD";
+  if (currentPrice < lower) {
+    signal = "BUY zone";
+  } else if (currentPrice > upper) {
+    signal = "TRIM zone";
+  }
+
+  return {
+    ticker: holding.ticker,
+    pctWindow,
+    price: formatCurrency(currentPrice),
+    lower: formatCurrency(lower),
+    upper: formatCurrency(upper),
+    signal,
+  };
+}
+
+export function computeDashboardMetrics(holdings, currentPrices) {
+  return holdings.reduce(
+    (acc, holding) => {
+      const price = currentPrices[holding.ticker] ?? 0;
+      const value = holding.shares * price;
+      acc.totalValue += value;
+      acc.totalCost += holding.cost;
+      acc.totalRealised += holding.realised;
+      acc.totalUnrealised += value - holding.cost;
+      return acc;
+    },
+    {
+      totalValue: 0,
+      totalCost: 0,
+      totalRealised: 0,
+      totalUnrealised: 0,
+      holdingsCount: holdings.length,
+    },
+  );
+}

--- a/src/utils/roi.js
+++ b/src/utils/roi.js
@@ -1,0 +1,84 @@
+function findClosestPrice(series, targetDate) {
+  if (!Array.isArray(series) || series.length === 0) {
+    return 0;
+  }
+
+  let previous = series[0].close ?? 0;
+  for (const point of series) {
+    if (point.date === targetDate) {
+      return point.close ?? previous;
+    }
+
+    if (point.date > targetDate) {
+      return previous;
+    }
+
+    previous = point.close ?? previous;
+  }
+
+  return previous;
+}
+
+export async function buildRoiSeries(transactions, priceFetcher) {
+  if (!Array.isArray(transactions) || transactions.length === 0) {
+    return [];
+  }
+
+  const tickers = [...new Set(transactions.map((tx) => tx.ticker))];
+  const symbols = [...tickers, "spy"];
+  const priceMapEntries = await Promise.all(
+    symbols.map(async (symbol) => {
+      const data = await priceFetcher(symbol);
+      return [symbol, data];
+    }),
+  );
+  const priceMap = Object.fromEntries(priceMapEntries);
+  const spySeries = priceMap.spy ?? [];
+  if (spySeries.length === 0) {
+    return [];
+  }
+
+  const cumulativeShares = Object.fromEntries(
+    tickers.map((ticker) => [ticker, 0]),
+  );
+  let initialValue = null;
+  const initialSpyPrice = spySeries[0].close ?? 0;
+
+  return spySeries.map((point) => {
+    const date = point.date;
+    transactions
+      .filter((tx) => tx.date === date)
+      .forEach((tx) => {
+        if (tx.type === "BUY") {
+          cumulativeShares[tx.ticker] += tx.shares;
+        } else if (tx.type === "SELL") {
+          cumulativeShares[tx.ticker] -= tx.shares;
+        }
+      });
+
+    const portfolioValue = tickers.reduce((total, ticker) => {
+      const price = findClosestPrice(priceMap[ticker], date);
+      return total + cumulativeShares[ticker] * price;
+    }, 0);
+
+    if (initialValue === null) {
+      initialValue = portfolioValue;
+    }
+
+    const portfolioRoi =
+      initialValue === 0
+        ? 0
+        : ((portfolioValue - initialValue) / initialValue) * 100;
+    const spyPrice = point.close ?? initialSpyPrice;
+    const spyRoi =
+      initialSpyPrice === 0
+        ? 0
+        : ((spyPrice - initialSpyPrice) / initialSpyPrice) * 100;
+
+    return {
+      date,
+      portfolio: Number(portfolioRoi.toFixed(3)),
+      spy: Number(spyRoi.toFixed(3)),
+    };
+  });
+}


### PR DESCRIPTION
## Summary
- replace the monolithic `App.jsx` layout with a three-tab workspace and reusable tab/button/controls components for portfolio navigation, holdings management, and transaction entry【F:src/App.jsx†L1-L185】【F:src/components/TabBar.jsx†L1-L17】【F:src/components/PortfolioControls.jsx†L1-L77】
- introduce dedicated dashboard, holdings, and transactions tab components plus shared utility modules for API access, formatting, holdings aggregation, and ROI series generation【F:src/components/DashboardTab.jsx†L1-L153】【F:src/components/HoldingsTab.jsx†L1-L156】【F:src/components/TransactionsTab.jsx†L1-L194】【F:src/utils/api.js†L1-L37】【F:src/utils/holdings.js†L1-L99】【F:src/utils/roi.js†L1-L84】【F:src/utils/format.js†L1-L19】
- expand documentation, styling, and lint tooling coverage while adding comprehensive tests to keep the new UI and utilities above 90% coverage【F:README.md†L5-L70】【F:src/index.css†L5-L20】【F:eslint.config.js†L4-L27】【F:src/__tests__/App.test.jsx†L1-L135】【F:src/__tests__/holdings.test.js†L1-L60】【F:src/__tests__/roi.test.js†L1-L80】【F:src/__tests__/format.test.js†L1-L17】

## Testing
- `npx prettier --check .`
- `npm run lint`
- `npm run test`
- `npm run build`
- `npx markdown-link-check README.md`
- `bandit -ll -r .`
- `gitleaks detect --no-banner`
- `pip-audit`


------
https://chatgpt.com/codex/tasks/task_e_68e135fb522c832f94f6231a1c333f0e