### PR TITLE
Add undo control for portfolio transactions

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -157,6 +157,12 @@ export default function App() {
     setTransactions((prev) => [...prev, transaction]);
   }, []);
 
+  const handleDeleteTransaction = useCallback((indexToRemove) => {
+    setTransactions((prev) =>
+      prev.filter((_, index) => index !== indexToRemove),
+    );
+  }, []);
+
   const handleSignalChange = useCallback((ticker, pct) => {
     const pctValue = Number.parseFloat(pct);
     if (!Number.isFinite(pctValue)) {
@@ -259,6 +265,7 @@ export default function App() {
             <TransactionsTab
               transactions={transactions}
               onAddTransaction={handleAddTransaction}
+              onDeleteTransaction={handleDeleteTransaction}
             />
           )}
 

--- a/src/__tests__/App.test.jsx
+++ b/src/__tests__/App.test.jsx
@@ -161,4 +161,39 @@ describe("App tab navigation", () => {
     assert.ok(await screen.findByText("AAPL"));
     assert.ok(await screen.findByText("$1,000.00"));
   });
+
+  it("allows undoing a transaction from the transactions table", async () => {
+    render(<App />);
+
+    const transactionsTab = screen.getByRole("button", {
+      name: /transactions/i,
+    });
+    await userEvent.click(transactionsTab);
+
+    const dateInput = screen.getByLabelText("Date");
+    fireEvent.input(dateInput, { target: { value: "2024-01-03" } });
+
+    const tickerInput = screen.getByLabelText("Ticker");
+    await userEvent.type(tickerInput, "msft");
+
+    const amountInput = screen.getByLabelText("Amount (USD)");
+    await userEvent.type(amountInput, "1500");
+
+    const priceInput = screen.getByLabelText("Price (USD)");
+    await userEvent.type(priceInput, "250");
+
+    const submitButton = screen.getByRole("button", {
+      name: /add transaction/i,
+    });
+    await userEvent.click(submitButton);
+
+    const undoButton = await screen.findByRole("button", {
+      name: /undo transaction for MSFT on 2024-01-03/i,
+    });
+    await userEvent.click(undoButton);
+
+    assert.ok(
+      await screen.findByText("No transactions recorded yet."),
+    );
+  });
 });

--- a/src/components/TransactionsTab.jsx
+++ b/src/components/TransactionsTab.jsx
@@ -9,7 +9,7 @@ const defaultForm = {
   price: "",
 };
 
-function TransactionsTable({ transactions }) {
+function TransactionsTable({ transactions, onDeleteTransaction }) {
   if (transactions.length === 0) {
     return (
       <p className="text-sm text-slate-500 dark:text-slate-400">
@@ -29,6 +29,7 @@ function TransactionsTable({ transactions }) {
             <th className="px-3 py-2">Amount</th>
             <th className="px-3 py-2">Price</th>
             <th className="px-3 py-2">Shares</th>
+            <th className="px-3 py-2 text-right">Actions</th>
           </tr>
         </thead>
         <tbody className="divide-y divide-slate-200 dark:divide-slate-800">
@@ -45,6 +46,16 @@ function TransactionsTable({ transactions }) {
               </td>
               <td className="px-3 py-2">{formatCurrency(transaction.price)}</td>
               <td className="px-3 py-2">{transaction.shares.toFixed(4)}</td>
+              <td className="px-3 py-2 text-right">
+                <button
+                  type="button"
+                  onClick={() => onDeleteTransaction?.(index)}
+                  className="rounded-md border border-transparent px-3 py-1 text-xs font-semibold text-rose-600 hover:bg-rose-50 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-rose-500 dark:hover:bg-rose-500/10"
+                  aria-label={`Undo transaction for ${transaction.ticker} on ${transaction.date}`}
+                >
+                  Undo
+                </button>
+              </td>
             </tr>
           ))}
         </tbody>
@@ -53,7 +64,11 @@ function TransactionsTable({ transactions }) {
   );
 }
 
-export default function TransactionsTab({ onAddTransaction, transactions }) {
+export default function TransactionsTab({
+  onAddTransaction,
+  onDeleteTransaction,
+  transactions,
+}) {
   const [form, setForm] = useState(defaultForm);
   const [error, setError] = useState(null);
 
@@ -186,7 +201,10 @@ export default function TransactionsTab({ onAddTransaction, transactions }) {
           Recent Activity
         </h2>
         <div className="mt-4">
-          <TransactionsTable transactions={transactions} />
+          <TransactionsTable
+            transactions={transactions}
+            onDeleteTransaction={onDeleteTransaction}
+          />
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- add a state handler to remove previously recorded transactions
- surface an Undo button for each transaction in the Recent Activity table
- cover the new flow with an integration test through App.test.jsx

## Testing
- npm run lint
- npm test *(fails: ERR_MODULE_NOT_FOUND for 'uuid' in existing server tests; present prior to this change)*

📊 COMPLIANCE: 5/6 rules met (missing: R4 – backend test suite currently fails because the repository cannot resolve 'uuid')
🤖 Model: gpt-5-codex-medium
🧪 Tests: updated (App.test.jsx); coverage from npm test unavailable due to failure noted above
🔐 Security: bandit/gitleaks/pip-audit deferred to CI
⚠️ Failed: R4


------
https://chatgpt.com/codex/tasks/task_e_68e155048aa8832fa1d9e039ab2b7084