### PR TITLE
Add HTTP hardening middleware and docs updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,10 @@ To deploy the static frontend to GitHub Pages and run the backend separately:
 
 3. Deploy the backend to your preferred host (Heroku, Railway, Cloudflare Workers with minimal adjustments). For Cloudflare Workers, you can port the express logic to `fetch` handlers and use KV for storage.
 
+### HTTPS & transport security
+
+Always terminate traffic for the Express API behind HTTPS with HTTP Strict Transport Security (HSTS) enabled at your edge proxy or load balancer. Plaintext HTTP must never be exposed in production—enforce automatic redirects to HTTPS and configure long-lived HSTS policies for continued protection.
+
 ## API
 
 ### `GET /api/prices/:symbol?range=1y`

--- a/docs/HARDENING_SCOREBOARD.md
+++ b/docs/HARDENING_SCOREBOARD.md
@@ -5,13 +5,13 @@
 | G3      | Security audit gate              | MEDIUM   |       | TODO         |                   |    |               |
 | G4      | Test artifacts                   | LOW      |       | TODO         |                   |    |               |
 | G5      | Release gate                     | HIGH     |       | TODO         |                   |    |               |
-| SEC-1   | Rate limiting                    | CRITICAL |       | TODO         |                   |    |               |
-| SEC-2   | JSON size limits                 | HIGH     |       | TODO         |                   |    |               |
+| SEC-1   | Rate limiting                    | CRITICAL |       | DONE         | feat/security-hardening | [Compare](https://github.com/cortega26/portfolio-manager-server/compare/main...feat/security-hardening) |               |
+| SEC-2   | JSON size limits                 | HIGH     |       | DONE         | feat/security-hardening | [Compare](https://github.com/cortega26/portfolio-manager-server/compare/main...feat/security-hardening) |               |
 | SEC-3   | Per-portfolio API key            | HIGH*    |       | TODO         |                   |    |               |
-| SEC-4   | Uniform error handler            | MEDIUM   |       | TODO         |                   |    |               |
-| SEC-5   | HTTPS/HSTS                       | HIGH     |       | TODO         |                   |    |               |
-| SEC-6   | Helmet + CSP                     | HIGH     |       | TODO         |                   |    |               |
-| SEC-7   | Strict CORS                      | HIGH     |       | TODO         |                   |    |               |
+| SEC-4   | Uniform error handler            | MEDIUM   |       | DONE         | feat/security-hardening | [Compare](https://github.com/cortega26/portfolio-manager-server/compare/main...feat/security-hardening) |               |
+| SEC-5   | HTTPS/HSTS                       | HIGH     |       | DONE         | feat/security-hardening | [Compare](https://github.com/cortega26/portfolio-manager-server/compare/main...feat/security-hardening) |               |
+| SEC-6   | Helmet + CSP                     | HIGH     |       | DONE         | feat/security-hardening | [Compare](https://github.com/cortega26/portfolio-manager-server/compare/main...feat/security-hardening) |               |
+| SEC-7   | Strict CORS                      | HIGH     |       | DONE         | feat/security-hardening | [Compare](https://github.com/cortega26/portfolio-manager-server/compare/main...feat/security-hardening) |               |
 | SEC-8   | CSV/Excel injection guard        | MEDIUM   |       | TODO         |                   |    |               |
 | STO-1   | Atomic writes                    | CRITICAL |       | TODO         |                   |    |               |
 | STO-2   | Per-portfolio mutex              | CRITICAL |       | TODO         |                   |    |               |

--- a/server/__tests__/portfolio.test.js
+++ b/server/__tests__/portfolio.test.js
@@ -53,7 +53,8 @@ test('rejects invalid portfolio identifiers to prevent path traversal', async ()
   );
   assert.equal(response.status, 400);
   assert.deepEqual(response.body, {
-    error: 'Invalid portfolio id. Use letters, numbers, hyphen or underscore.',
+    error: 'INVALID_PORTFOLIO_ID',
+    message: 'Invalid portfolio id. Use letters, numbers, hyphen or underscore.',
   });
 });
 
@@ -64,7 +65,8 @@ test('rejects non-object portfolio payloads', async () => {
     .send(['not', 'an', 'object']);
   assert.equal(response.status, 400);
   assert.deepEqual(response.body, {
-    error: 'Portfolio payload must be a JSON object.',
+    error: 'INVALID_PORTFOLIO_PAYLOAD',
+    message: 'Portfolio payload must be a JSON object.',
   });
 });
 
@@ -85,7 +87,7 @@ test('GET /api/prices/:symbol rejects invalid symbol input', async () => {
   const app = createApp({ dataDir, logger: noopLogger });
   const response = await request(app).get('/api/prices/INVALID!');
   assert.equal(response.status, 400);
-  assert.deepEqual(response.body, { error: 'Failed to fetch historical prices' });
+  assert.deepEqual(response.body, { error: 'INVALID_SYMBOL', message: 'Invalid symbol.' });
 });
 
 test('GET /api/prices/:symbol handles upstream fetch failures', async () => {
@@ -96,7 +98,10 @@ test('GET /api/prices/:symbol handles upstream fetch failures', async () => {
   const app = createApp({ dataDir, logger: noopLogger, fetchImpl });
   const response = await request(app).get('/api/prices/AAPL');
   assert.equal(response.status, 502);
-  assert.deepEqual(response.body, { error: 'Failed to fetch historical prices' });
+  assert.deepEqual(response.body, {
+    error: 'PRICE_FETCH_FAILED',
+    message: 'Failed to fetch historical prices.',
+  });
 });
 
 test('GET /api/portfolio/:id returns 500 when stored data is invalid', async () => {
@@ -104,7 +109,10 @@ test('GET /api/portfolio/:id returns 500 when stored data is invalid', async () 
   writeFileSync(path.join(dataDir, 'portfolio_corrupt.json'), '{ invalid');
   const response = await request(app).get('/api/portfolio/corrupt');
   assert.equal(response.status, 500);
-  assert.deepEqual(response.body, { error: 'Failed to load portfolio' });
+  assert.deepEqual(response.body, {
+    error: 'PORTFOLIO_READ_FAILED',
+    message: 'Unexpected server error',
+  });
 });
 
 test('isValidPortfolioId accepts generated safe identifiers', () => {


### PR DESCRIPTION
## Summary
- enable Helmet with a minimal CSP/HSTS profile, disable Express power header, and layer global plus portfolio-specific rate limits driven by express-rate-limit
- enforce an environment-driven strict CORS allowlist, centralized JSON size limits, and a shared error handler that normalizes API error payloads
- update portfolio API tests for the new error contract, document HTTPS/HSTS expectations, and mark the hardening scoreboard items as complete

## Testing
- `npm test`
- `ruff check .`
- `black --check .`
- `isort --check-only .`
- `mypy .`
- `pytest -q`
- `bandit -ll -r .` *(missing: command not found, deferred to CI)*
- `gitleaks detect` *(missing: command not found, deferred to CI)*
- `pip-audit` *(missing: command not found, deferred to CI)*

📊 COMPLIANCE: 5/7 rules met (R2 deferred to CI tooling, R3 coverage below 90% on server/app.js)
🤖 Model: gpt-5-codex-high
🧪 Tests: updated; `npm test` (lines 90.22%, branches 80.08%)
🔐 Security: bandit/gitleaks/pip-audit unavailable locally; marked deferred to CI
⚠️ Failed: R2, R3

------
https://chatgpt.com/codex/tasks/task_e_68e281c46748832f8b334294353a2b20