### PR TITLE
Implement validation middleware and paginate list endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,16 +167,24 @@ Loads a saved portfolio with the given `id` from the `data` folder. The identifi
 
 ### `POST /api/portfolio/:id`
 
-Saves a portfolio to the backend. The request body must be a JSON object representing your portfolio state. The identifier is validated using the same `[A-Za-z0-9_-]{1,64}` rule, and payloads that are not plain JSON objects return HTTP `400`. Valid portfolios are stored as `data/portfolio_<id>.json`.
+Saves a portfolio to the backend. Bodies are validated against the schema in [`server/middleware/validation.js`](server/middleware/validation.js):
+
+- `transactions` must be an array of transaction objects (`date`, `ticker`, `type`, `amount`, optional `quantity`/`shares`, etc.).
+- Optional `signals` map tickers to `{ pct: number }` windows.
+- Optional `settings.autoClip` flag.
+
+The identifier is validated using the same `[A-Za-z0-9_-]{1,64}` rule. Invalid identifiers or payloads yield HTTP `400` with `{ error: "VALIDATION_ERROR", details: [...] }`. Valid portfolios are stored as `data/portfolio_<id>.json`.
 
 ### Cash & benchmark endpoints
 
 When the `features.cash_benchmarks` flag is active the API also exposes:
 
-- `GET /api/returns/daily?from=YYYY-MM-DD&to=YYYY-MM-DD&views=port,excash,spy,bench`
-- `GET /api/nav/daily?from=YYYY-MM-DD&to=YYYY-MM-DD` (includes `stale_price` flag)
+- `GET /api/returns/daily?from=YYYY-MM-DD&to=YYYY-MM-DD&views=port,excash,spy,bench&page=1&per_page=100`
+- `GET /api/nav/daily?from=YYYY-MM-DD&to=YYYY-MM-DD&page=1&per_page=100` (includes `stale_price` flag)
 - `GET /api/benchmarks/summary?from=YYYY-MM-DD&to=YYYY-MM-DD`
 - `POST /api/admin/cash-rate` accepting `{ "effective_date": "YYYY-MM-DD", "apy": 0.04 }`
+
+List endpoints support `page`/`per_page` pagination (defaults: page 1, `per_page` 100) and return an additional `meta` block plus `ETag` headers for conditional requests.
 
 Refer to [`docs/openapi.yaml`](docs/openapi.yaml) for detailed schemas and sample responses.
 

--- a/docs/HARDENING_SCOREBOARD.md
+++ b/docs/HARDENING_SCOREBOARD.md
@@ -20,10 +20,10 @@
 | MTH-1   | Decimal math policy              | CRITICAL |       | TODO         |                   |    |               |
 | MTH-2   | TWR/MWR & benchmark policy       | HIGH     |       | TODO         |                   |    |               |
 | MTH-3   | Cash accruals doc & proration    | MEDIUM   |       | TODO         |                   |    |               |
-| COM-1   | Request validation (zod)         | CRITICAL |       | TODO         |                   |    |               |
+| COM-1   | Request validation (zod)         | CRITICAL |       | DONE         | feat/com-validation | [Compare](https://github.com/cortega26/portfolio-manager-server/compare/main...feat/com-validation) | Local: lint/test |
 | COM-2   | Oversell reject + opt clip       | HIGH     |       | TODO         |                   |    |               |
 | COM-3   | Same-day determinism rules       | MEDIUM   |       | TODO         |                   |    |               |
-| COM-4   | Error codes & pagination         | MEDIUM   |       | TODO         |                   |    |               |
+| COM-4   | Error codes & pagination         | MEDIUM   |       | DONE         | feat/com-validation | [Compare](https://github.com/cortega26/portfolio-manager-server/compare/main...feat/com-validation) | Local: lint/test |
 | PERF-1  | Price caching + stale guard      | HIGH     |       | TODO         |                   |    |               |
 | PERF-2  | Incremental holdings             | MEDIUM   |       | TODO         |                   |    |               |
 | PERF-3  | UI virtualization/pagination     | LOW      |       | TODO         |                   |    |               |

--- a/docs/cash-benchmarks.md
+++ b/docs/cash-benchmarks.md
@@ -61,10 +61,12 @@ The CLI `npm run backfill -- --from=YYYY-MM-DD --to=YYYY-MM-DD` replays the same
 
 The feature flag exposes new JSON endpoints:
 
-- `GET /api/returns/daily?from=YYYY-MM-DD&to=YYYY-MM-DD&views=port,excash,spy,bench`
-- `GET /api/nav/daily?from=YYYY-MM-DD&to=YYYY-MM-DD`
+- `GET /api/returns/daily?from=YYYY-MM-DD&to=YYYY-MM-DD&views=port,excash,spy,bench&page=1&per_page=100`
+- `GET /api/nav/daily?from=YYYY-MM-DD&to=YYYY-MM-DD&page=1&per_page=100`
 - `GET /api/benchmarks/summary?from=YYYY-MM-DD&to=YYYY-MM-DD`
 - `POST /api/admin/cash-rate { effective_date, apy }`
+
+`page`/`per_page` query parameters are optional (defaults: `1` and `100`) and paginate the time-series data. Responses for list endpoints include a `meta` block (`page`, `per_page`, `total`, `total_pages`) plus `ETag` headers so clients can issue conditional requests. Validation errors are surfaced as HTTP `400` with `{ error: "VALIDATION_ERROR", details: [...] }`.
 
 See [`docs/openapi.yaml`](./openapi.yaml) for schemas and examples.
 

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -25,6 +25,21 @@ paths:
           schema:
             type: string
           description: Comma separated list of views (port, excash, spy, bench)
+        - in: query
+          name: page
+          schema:
+            type: integer
+            minimum: 1
+            default: 1
+          description: Page number (1-indexed)
+        - in: query
+          name: per_page
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 500
+            default: 100
+          description: Page size (max 500)
       responses:
         '200':
           description: Daily return series
@@ -46,6 +61,13 @@ paths:
                         $ref: '#/components/schemas/DateValueSeries'
                       r_cash:
                         $ref: '#/components/schemas/DateValueSeries'
+                  meta:
+                    $ref: '#/components/schemas/PaginationMeta'
+          headers:
+            ETag:
+              schema:
+                type: string
+              description: Strong validator for conditional requests
   /api/nav/daily:
     get:
       summary: Daily NAV snapshots and sleeve weights
@@ -60,6 +82,21 @@ paths:
           schema:
             type: string
             format: date
+        - in: query
+          name: page
+          schema:
+            type: integer
+            minimum: 1
+            default: 1
+          description: Page number (1-indexed)
+        - in: query
+          name: per_page
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 500
+            default: 100
+          description: Page size (max 500)
       responses:
         '200':
           description: NAV series
@@ -93,6 +130,13 @@ paths:
                               type: number
                             risk:
                               type: number
+                  meta:
+                    $ref: '#/components/schemas/PaginationMeta'
+          headers:
+            ETag:
+              schema:
+                type: string
+              description: Strong validator for conditional requests
   /api/benchmarks/summary:
     get:
       summary: Cumulative returns and drag metrics
@@ -162,6 +206,17 @@ components:
             format: date
           value:
             type: number
+    PaginationMeta:
+      type: object
+      properties:
+        page:
+          type: integer
+        per_page:
+          type: integer
+        total:
+          type: integer
+        total_pages:
+          type: integer
     ReturnSummary:
       type: object
       properties:

--- a/server/__tests__/api_validation.test.js
+++ b/server/__tests__/api_validation.test.js
@@ -1,0 +1,139 @@
+import assert from 'node:assert/strict';
+import { afterEach, beforeEach, test } from 'node:test';
+import { mkdtempSync, rmSync } from 'node:fs';
+import path from 'node:path';
+import { tmpdir } from 'node:os';
+
+import request from 'supertest';
+
+import { createApp } from '../app.js';
+import JsonTableStorage from '../data/storage.js';
+
+const noopLogger = { info() {}, warn() {}, error() {} };
+
+let dataDir;
+let app;
+let storage;
+
+beforeEach(async () => {
+  dataDir = mkdtempSync(path.join(tmpdir(), 'api-validation-'));
+  storage = new JsonTableStorage({ dataDir, logger: noopLogger });
+  await storage.ensureTable('transactions', []);
+  await storage.ensureTable('cash_rates', []);
+  await storage.ensureTable('returns_daily', []);
+  await storage.ensureTable('nav_snapshots', []);
+  app = createApp({
+    dataDir,
+    logger: noopLogger,
+    config: { featureFlags: { cashBenchmarks: true }, cors: { allowedOrigins: [] } },
+  });
+});
+
+afterEach(() => {
+  rmSync(dataDir, { recursive: true, force: true });
+});
+
+test('POST /api/portfolio rejects invalid payloads with validation details', async () => {
+  const response = await request(app)
+    .post('/api/portfolio/test123')
+    .send({ transactions: [{ type: 'BUY', amount: 'invalid' }] })
+    .set('Content-Type', 'application/json');
+
+  assert.equal(response.status, 400);
+  assert.equal(response.body.error, 'VALIDATION_ERROR');
+  assert.ok(Array.isArray(response.body.details));
+  assert.ok(response.body.details.length > 0);
+});
+
+test('POST /api/portfolio rejects invalid portfolio id', async () => {
+  const response = await request(app)
+    .post('/api/portfolio/bad id')
+    .send({ transactions: [] })
+    .set('Content-Type', 'application/json');
+
+  assert.equal(response.status, 400);
+  assert.equal(response.body.error, 'VALIDATION_ERROR');
+  assert.ok(Array.isArray(response.body.details));
+});
+
+test('GET /api/returns/daily paginates and emits ETag', async () => {
+  const rows = [
+    { date: '2024-01-01', r_port: 0.01, r_ex_cash: 0.009, r_spy_100: 0.012, r_bench_blended: 0.011, r_cash: 0.0001 },
+    { date: '2024-01-02', r_port: 0.02, r_ex_cash: 0.018, r_spy_100: 0.019, r_bench_blended: 0.0185, r_cash: 0.0002 },
+    { date: '2024-01-03', r_port: -0.005, r_ex_cash: -0.006, r_spy_100: -0.004, r_bench_blended: -0.0045, r_cash: 0.0003 },
+  ];
+  await storage.writeTable('returns_daily', rows);
+
+  const first = await request(app).get('/api/returns/daily?per_page=2');
+  assert.equal(first.status, 200);
+  assert.ok(first.headers.etag);
+  assert.equal(first.body.meta.page, 1);
+  assert.equal(first.body.meta.per_page, 2);
+  assert.equal(first.body.meta.total, 3);
+  assert.equal(first.body.meta.total_pages, 2);
+  assert.equal(first.body.series.r_port.length, 2);
+  assert.equal(first.body.series.r_cash.length, 2);
+
+  const second = await request(app)
+    .get('/api/returns/daily?per_page=2')
+    .set('If-None-Match', first.headers.etag);
+  assert.equal(second.status, 304);
+});
+
+test('GET /api/returns/daily validates pagination parameters', async () => {
+  const response = await request(app).get('/api/returns/daily?per_page=0');
+  assert.equal(response.status, 400);
+  assert.equal(response.body.error, 'VALIDATION_ERROR');
+  assert.ok(Array.isArray(response.body.details));
+});
+
+test('GET /api/nav/daily returns paginated snapshots with ETag', async () => {
+  const rows = [
+    {
+      date: '2024-01-01',
+      portfolio_nav: 1000,
+      ex_cash_nav: 800,
+      cash_balance: 200,
+      risk_assets_value: 800,
+      stale_price: false,
+    },
+    {
+      date: '2024-01-02',
+      portfolio_nav: 1010,
+      ex_cash_nav: 805,
+      cash_balance: 205,
+      risk_assets_value: 805,
+      stale_price: false,
+    },
+    {
+      date: '2024-01-03',
+      portfolio_nav: 1020,
+      ex_cash_nav: 810,
+      cash_balance: 210,
+      risk_assets_value: 810,
+      stale_price: true,
+    },
+  ];
+  await storage.writeTable('nav_snapshots', rows);
+
+  const response = await request(app).get('/api/nav/daily?per_page=2&page=2');
+  assert.equal(response.status, 200);
+  assert.ok(response.headers.etag);
+  assert.equal(response.body.meta.page, 2);
+  assert.equal(response.body.meta.per_page, 2);
+  assert.equal(response.body.meta.total, 3);
+  assert.equal(response.body.meta.total_pages, 2);
+  assert.equal(response.body.data.length, 1);
+  assert.equal(response.body.data[0].date, '2024-01-03');
+});
+
+test('POST /api/admin/cash-rate enforces body validation', async () => {
+  const response = await request(app)
+    .post('/api/admin/cash-rate')
+    .send({ effective_date: 'not-a-date', apy: 'abc' })
+    .set('Content-Type', 'application/json');
+
+  assert.equal(response.status, 400);
+  assert.equal(response.body.error, 'VALIDATION_ERROR');
+  assert.ok(Array.isArray(response.body.details));
+});

--- a/server/__tests__/daily_close.test.js
+++ b/server/__tests__/daily_close.test.js
@@ -127,12 +127,14 @@ test('API endpoints expose computed series', async () => {
   );
   assert.equal(returnsResponse.status, 200);
   assert.ok(Array.isArray(returnsResponse.body.series.r_port));
+  assert.ok(returnsResponse.body.meta);
 
   const navResponse = await request(app).get(
     '/api/nav/daily?from=2024-01-02&to=2024-01-02',
   );
   assert.equal(navResponse.status, 200);
   assert.ok(Array.isArray(navResponse.body.data));
+  assert.ok(navResponse.body.data.length > 0);
   assert.equal(navResponse.body.data[0].stale_price, false);
 
   const summaryResponse = await request(app).get(

--- a/server/middleware/validation.js
+++ b/server/middleware/validation.js
@@ -1,0 +1,254 @@
+import { z } from 'zod';
+
+const ISO_DATE_REGEX = /^\d{4}-(0[1-9]|1[0-2])-(0[1-9]|[12]\d|3[01])$/u;
+const PORTFOLIO_ID_REGEX = /^[A-Za-z0-9_-]{1,64}$/u;
+const SYMBOL_REGEX = /^[A-Za-z0-9._-]{1,32}$/u;
+
+const sanitizeString = (schema) =>
+  z.preprocess((value) => (typeof value === 'string' ? value.trim() : value), schema);
+
+const isoDateSchema = sanitizeString(
+  z
+    .string({ invalid_type_error: 'Expected ISO date string' })
+    .regex(ISO_DATE_REGEX, 'Must be ISO date (YYYY-MM-DD)'),
+);
+
+const portfolioIdSchema = sanitizeString(
+  z
+    .string({ invalid_type_error: 'Portfolio id must be a string' })
+    .regex(PORTFOLIO_ID_REGEX, 'Portfolio id must match [A-Za-z0-9_-]{1,64}'),
+);
+
+const tickerSchema = sanitizeString(
+  z
+    .string({ invalid_type_error: 'Ticker must be a string' })
+    .min(1, 'Ticker is required')
+    .max(32, 'Ticker must be at most 32 characters')
+    .regex(SYMBOL_REGEX, 'Ticker must match [A-Za-z0-9._-]{1,32}')
+    .transform((value) => value.toUpperCase()),
+);
+
+const numeric = (message) =>
+  z
+    .number({ invalid_type_error: message })
+    .refine((value) => Number.isFinite(value), message);
+
+const transactionTypeSchema = z
+  .enum(['BUY', 'SELL', 'DIVIDEND', 'DEPOSIT', 'WITHDRAWAL', 'INTEREST', 'FEE'])
+  .transform((value) => value.toUpperCase());
+
+const inputTransactionTypeSchema = z.preprocess((value) => {
+  if (typeof value === 'string') {
+    const normalized = value.trim().toUpperCase();
+    if (normalized === 'WITHDRAW') {
+      return 'WITHDRAWAL';
+    }
+    return normalized;
+  }
+  return value;
+}, transactionTypeSchema);
+
+const transactionSchema = z
+  .object({
+    id: sanitizeString(z.string().min(1).max(128)).optional(),
+    date: isoDateSchema,
+    ticker: tickerSchema.optional(),
+    type: inputTransactionTypeSchema,
+    amount: numeric('Amount must be a finite number'),
+    price: numeric('Price must be a finite number').nonnegative('Price cannot be negative').optional(),
+    quantity: numeric('Quantity must be a finite number').optional(),
+    shares: numeric('Shares must be a finite number').optional(),
+    note: sanitizeString(z.string().max(1024)).optional(),
+    metadata: z.record(z.unknown()).optional(),
+    internal: z.boolean().optional(),
+  })
+  .transform((value) => {
+    const ticker = value.ticker ?? null;
+    const canonicalTicker = ticker ? ticker.toUpperCase() : null;
+    let quantity = value.quantity;
+    if (typeof quantity !== 'number' && typeof value.shares === 'number') {
+      const shares = value.shares;
+      switch (value.type) {
+        case 'SELL':
+          quantity = -Math.abs(shares);
+          break;
+        case 'BUY':
+          quantity = Math.abs(shares);
+          break;
+        default:
+          quantity = shares;
+          break;
+      }
+    }
+    if (typeof quantity !== 'number') {
+      quantity = 0;
+    }
+    const amount = Number(value.amount);
+    return {
+      ...value,
+      ticker: canonicalTicker ?? undefined,
+      quantity: Number(quantity),
+      amount,
+    };
+  })
+  .superRefine((value, ctx) => {
+    if (
+      !value.ticker &&
+      !['DEPOSIT', 'WITHDRAWAL', 'DIVIDEND', 'INTEREST', 'FEE'].includes(value.type)
+    ) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'Ticker is required for non-cash transactions',
+        path: ['ticker'],
+      });
+    }
+  });
+
+const signalConfigSchema = z
+  .object({
+    pct: numeric('Signal percentage must be a finite number')
+      .min(0, 'Percentage must be non-negative')
+      .max(100, 'Percentage cannot exceed 100'),
+  })
+  .transform((value) => ({ pct: Number(value.pct) }));
+
+const signalsSchema = z
+  .object({})
+  .catchall(signalConfigSchema)
+  .superRefine((value, ctx) => {
+    for (const key of Object.keys(value)) {
+      const normalized = key.trim().toUpperCase();
+      if (!SYMBOL_REGEX.test(normalized)) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: 'Signal ticker must match [A-Za-z0-9._-]{1,32}',
+          path: [key],
+        });
+      }
+    }
+  })
+  .transform((value) => {
+    const result = {};
+    for (const [key, config] of Object.entries(value)) {
+      const normalized = key.trim().toUpperCase();
+      result[normalized] = config;
+    }
+    return result;
+  });
+
+const portfolioBodySchema = z
+  .object({
+    transactions: z.array(transactionSchema).max(250_000).default([]),
+    signals: signalsSchema.optional().default({}),
+    settings: z
+      .object({
+        autoClip: z.boolean().default(false),
+      })
+      .partial()
+      .optional()
+      .default({}),
+  })
+  .transform((value) => ({
+    transactions: value.transactions,
+    signals: value.signals,
+    settings: { autoClip: Boolean(value.settings?.autoClip) },
+  }));
+
+const paginationSchema = z.object({
+  page: z.coerce.number().int().min(1).default(1),
+  per_page: z.coerce.number().int().min(1).max(500).default(100),
+});
+
+const returnsQuerySchema = z
+  .object({
+    from: isoDateSchema.optional(),
+    to: isoDateSchema.optional(),
+    views: sanitizeString(z.string())
+      .optional()
+      .transform((value) => {
+        if (!value) {
+          return ['port', 'excash', 'spy', 'bench'];
+        }
+        return value
+          .split(',')
+          .map((item) => item.trim().toLowerCase())
+          .filter(Boolean);
+      }),
+  })
+  .merge(paginationSchema)
+  .transform((value) => ({
+    from: value.from ?? null,
+    to: value.to ?? null,
+    views: Array.from(new Set(value.views)),
+    page: value.page,
+    perPage: value.per_page,
+  }));
+
+const rangeQuerySchema = z
+  .object({
+    from: isoDateSchema.optional(),
+    to: isoDateSchema.optional(),
+  })
+  .merge(paginationSchema)
+  .transform((value) => ({
+    from: value.from ?? null,
+    to: value.to ?? null,
+    page: value.page,
+    perPage: value.per_page,
+  }));
+
+const cashRateBodySchema = z.object({
+  effective_date: isoDateSchema,
+  apy: numeric('APY must be a finite number'),
+});
+
+const validationErrorFromZod = (error) => {
+  const details = error.issues.map((issue) => ({
+    path: issue.path,
+    message: issue.message,
+    code: issue.code,
+  }));
+  const err = new Error('Request validation failed.');
+  err.status = 400;
+  err.statusCode = 400;
+  err.code = 'VALIDATION_ERROR';
+  err.details = details;
+  err.expose = true;
+  return err;
+};
+
+const parseWith = (schema, sourceKey) => (req, _res, next) => {
+  const result = schema.safeParse(req[sourceKey] ?? {});
+  if (!result.success) {
+    next(validationErrorFromZod(result.error));
+    return;
+  }
+  req[sourceKey] = result.data;
+  next();
+};
+
+export const validatePortfolioIdParam = (req, _res, next) => {
+  const result = portfolioIdSchema.safeParse(req.params?.id);
+  if (!result.success) {
+    next(validationErrorFromZod(result.error));
+    return;
+  }
+  req.params.id = result.data;
+  next();
+};
+
+export const validatePortfolioBody = parseWith(portfolioBodySchema, 'body');
+export const validateCashRateBody = parseWith(cashRateBodySchema, 'body');
+export const validateReturnsQuery = parseWith(returnsQuerySchema, 'query');
+export const validateRangeQuery = parseWith(rangeQuerySchema, 'query');
+
+export {
+  isoDateSchema,
+  portfolioBodySchema,
+  paginationSchema,
+  returnsQuerySchema,
+  rangeQuerySchema,
+  cashRateBodySchema,
+  validationErrorFromZod,
+};
+


### PR DESCRIPTION
## Summary
- add a dedicated `server/middleware/validation.js` module with zod schemas and helpers for portfolio IDs, payloads, cash rate inputs, and paginated query params
- apply the validation middleware across portfolio and cash admin routes, paginate/ETag the cash benchmark list endpoints, and normalize error codes in `server/app.js`
- expand API coverage with `server/__tests__/api_validation.test.js` and refresh existing docs (README, cash benchmarks, OpenAPI, hardening scoreboard) to reflect validation, pagination, and ETag behaviour

## Testing
- npm run lint
- npm test
- npm audit --audit-level=moderate (reports 2 moderate esbuild/vite advisories; fix requires breaking upgrade)

## Compliance Report
📊 COMPLIANCE: 6/7 rules met (R2 – gitleaks unavailable locally; deferred to CI)
🤖 Model: gpt-5-codex-high
🧪 Tests: created/updated (node --test --experimental-test-coverage)
🔐 Security: npm audit (moderate issues pending upstream upgrade), gitleaks (not installed; deferred)
⚠️ Failed: R2

------
https://chatgpt.com/codex/tasks/task_e_68e284f87f8c832f9d66fb9daeabffcd