### PR TITLE
Add trading-day stale-data guard for prices and benchmarks

### DIFF
--- a/docs/cash-benchmarks.md
+++ b/docs/cash-benchmarks.md
@@ -70,6 +70,10 @@ The feature flag exposes new JSON endpoints:
 
 See [`docs/openapi.yaml`](./openapi.yaml) for schemas and examples.
 
+## Data Freshness Guard
+
+Price- and benchmark-derived responses enforce a trading-day-aware freshness threshold. The server inspects the latest available adjusted-close date for each payload and compares it to the configured maximum trading-day age. If the dataset is older than the threshold, the endpoint emits structured warnings and responds with HTTP `503`/`{ "error": "STALE_DATA" }` instead of returning stale analytics. Weekends and major U.S. market holidays are excluded from the age calculation so expected gaps (e.g., long weekends) do not trigger false positives.
+
 ## Configuration
 
 | Name | Type | Default | Required | Description |
@@ -79,6 +83,7 @@ See [`docs/openapi.yaml`](./openapi.yaml) for schemas and examples.
 | `FEATURES_CASH_BENCHMARKS` | boolean | `true` | No | Enables cash & benchmark endpoints/jobs. |
 | `JOB_NIGHTLY_HOUR` | number | `4` | No | UTC hour for the nightly accrual job. |
 | `CORS_ALLOWED_ORIGINS` | string (CSV) | _(empty)_ | No | Whitelist of origins allowed by the API CORS policy. |
+| `FRESHNESS_MAX_STALE_TRADING_DAYS` | number | `3` | No | Maximum allowable trading-day age before `/api/prices/:symbol` and `/api/benchmarks/summary` emit `503 STALE_DATA`. |
 
 ## Testing
 

--- a/server/__tests__/freshness_guard.test.js
+++ b/server/__tests__/freshness_guard.test.js
@@ -1,0 +1,77 @@
+import assert from 'node:assert/strict';
+import { afterEach, beforeEach, test } from 'node:test';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import request from 'supertest';
+
+import { createApp } from '../app.js';
+import JsonTableStorage from '../data/storage.js';
+
+const noopLogger = { info() {}, warn() {}, error() {} };
+
+class StaticPriceProvider {
+  constructor(rows) {
+    this.rows = rows;
+  }
+
+  async getDailyAdjustedClose() {
+    return this.rows;
+  }
+}
+
+let dataDir;
+let storage;
+
+beforeEach(async () => {
+  dataDir = mkdtempSync(path.join(tmpdir(), 'stale-guard-'));
+  storage = new JsonTableStorage({ dataDir, logger: noopLogger });
+  await storage.ensureTable('returns_daily', []);
+});
+
+afterEach(() => {
+  rmSync(dataDir, { recursive: true, force: true });
+});
+
+test('prices endpoint returns 503 for stale data', async () => {
+  const staleProvider = new StaticPriceProvider([
+    { date: '2000-01-03', adjClose: 100 },
+  ]);
+  const app = createApp({
+    logger: noopLogger,
+    priceProvider: staleProvider,
+    config: {
+      freshness: { maxStaleTradingDays: 1 },
+      featureFlags: { cashBenchmarks: true },
+    },
+  });
+  const response = await request(app).get('/api/prices/SPY');
+  assert.equal(response.status, 503);
+  assert.deepEqual(response.body, { error: 'STALE_DATA' });
+});
+
+test('benchmarks summary returns 503 when latest return is stale', async () => {
+  await storage.upsertRow(
+    'returns_daily',
+    {
+      date: '2000-01-03',
+      r_port: 0,
+      r_ex_cash: 0,
+      r_bench_blended: 0,
+      r_spy_100: 0,
+      r_cash: 0,
+    },
+    ['date'],
+  );
+  const app = createApp({
+    dataDir,
+    logger: noopLogger,
+    config: {
+      freshness: { maxStaleTradingDays: 1 },
+      featureFlags: { cashBenchmarks: true },
+    },
+  });
+  const response = await request(app).get('/api/benchmarks/summary');
+  assert.equal(response.status, 503);
+  assert.deepEqual(response.body, { error: 'STALE_DATA' });
+});

--- a/server/config.js
+++ b/server/config.js
@@ -47,6 +47,10 @@ export function loadConfig(env = process.env) {
   );
   const allowedOrigins = parseList(env.CORS_ALLOWED_ORIGINS, []);
   const nightlyHour = parseNumber(env.JOB_NIGHTLY_HOUR, 4);
+  const maxStaleTradingDays = parseNumber(
+    env.FRESHNESS_MAX_STALE_TRADING_DAYS,
+    3,
+  );
 
   return {
     dataDir,
@@ -59,6 +63,9 @@ export function loadConfig(env = process.env) {
     },
     cors: {
       allowedOrigins,
+    },
+    freshness: {
+      maxStaleTradingDays,
     },
   };
 }

--- a/server/utils/tradingDays.js
+++ b/server/utils/tradingDays.js
@@ -1,0 +1,136 @@
+import { toDateKey } from '../finance/cash.js';
+
+const MS_PER_DAY = 86_400_000;
+
+function nthWeekdayOfMonth(year, monthIndex, weekday, occurrence) {
+  const firstOfMonth = new Date(Date.UTC(year, monthIndex, 1));
+  const offset = (weekday - firstOfMonth.getUTCDay() + 7) % 7;
+  const day = 1 + offset + (occurrence - 1) * 7;
+  return new Date(Date.UTC(year, monthIndex, day));
+}
+
+function lastWeekdayOfMonth(year, monthIndex, weekday) {
+  const lastOfMonth = new Date(Date.UTC(year, monthIndex + 1, 0));
+  const offset = (lastOfMonth.getUTCDay() - weekday + 7) % 7;
+  const day = lastOfMonth.getUTCDate() - offset;
+  return new Date(Date.UTC(year, monthIndex, day));
+}
+
+function observedHoliday(year, monthIndex, dayOfMonth) {
+  const date = new Date(Date.UTC(year, monthIndex, dayOfMonth));
+  const day = date.getUTCDay();
+  if (day === 0) {
+    date.setUTCDate(date.getUTCDate() + 1);
+  } else if (day === 6) {
+    date.setUTCDate(date.getUTCDate() - 1);
+  }
+  return date;
+}
+
+function computeWesternEaster(year) {
+  const a = year % 19;
+  const b = Math.floor(year / 100);
+  const c = year % 100;
+  const d = Math.floor(b / 4);
+  const e = b % 4;
+  const f = Math.floor((b + 8) / 25);
+  const g = Math.floor((b - f + 1) / 3);
+  const h = (19 * a + b - d - g + 15) % 30;
+  const i = Math.floor(c / 4);
+  const k = c % 4;
+  const l = (32 + 2 * e + 2 * i - h - k) % 7;
+  const m = Math.floor((a + 11 * h + 22 * l) / 451);
+  const month = Math.floor((h + l - 7 * m + 114) / 31);
+  const day = ((h + l - 7 * m + 114) % 31) + 1;
+  return new Date(Date.UTC(year, month - 1, day));
+}
+
+const holidayCache = new Map();
+
+function buildUsMarketHolidays(year) {
+  if (holidayCache.has(year)) {
+    return holidayCache.get(year);
+  }
+
+  const holidays = new Set();
+
+  const add = (date) => {
+    holidays.add(toDateKey(date));
+  };
+
+  add(observedHoliday(year, 0, 1)); // New Year's Day
+  add(nthWeekdayOfMonth(year, 0, 1, 3)); // Martin Luther King Jr. Day (3rd Monday Jan)
+  add(nthWeekdayOfMonth(year, 1, 1, 3)); // Presidents' Day (3rd Monday Feb)
+
+  const easter = computeWesternEaster(year);
+  const goodFriday = new Date(easter.getTime() - 2 * MS_PER_DAY);
+  add(goodFriday);
+
+  add(lastWeekdayOfMonth(year, 4, 1)); // Memorial Day (last Monday May)
+  if (year >= 2021) {
+    add(observedHoliday(year, 5, 19)); // Juneteenth
+  }
+  add(observedHoliday(year, 6, 4)); // Independence Day
+  add(nthWeekdayOfMonth(year, 8, 1, 1)); // Labor Day (1st Monday Sep)
+  add(nthWeekdayOfMonth(year, 10, 4, 4)); // Thanksgiving (4th Thursday Nov)
+  add(observedHoliday(year, 11, 25)); // Christmas Day
+
+  holidayCache.set(year, holidays);
+  return holidays;
+}
+
+function toUtcDate(date) {
+  const key = toDateKey(date);
+  const parsed = new Date(`${key}T00:00:00Z`);
+  if (Number.isNaN(parsed.getTime())) {
+    return null;
+  }
+  return parsed;
+}
+
+export function isTradingDay(date) {
+  const parsed = toUtcDate(date);
+  if (!parsed) {
+    return false;
+  }
+  const day = parsed.getUTCDay();
+  if (day === 0 || day === 6) {
+    return false;
+  }
+  const holidays = buildUsMarketHolidays(parsed.getUTCFullYear());
+  return !holidays.has(toDateKey(parsed));
+}
+
+export function computeTradingDayAge(latestDate, referenceDate = new Date()) {
+  const latest = toUtcDate(latestDate);
+  const reference = toUtcDate(referenceDate);
+  if (!latest || !reference) {
+    return Number.POSITIVE_INFINITY;
+  }
+  if (reference.getTime() <= latest.getTime()) {
+    return 0;
+  }
+  let tradingDays = 0;
+  for (
+    let ts = latest.getTime() + MS_PER_DAY;
+    ts <= reference.getTime();
+    ts += MS_PER_DAY
+  ) {
+    const current = new Date(ts);
+    if (isTradingDay(current)) {
+      tradingDays += 1;
+    }
+  }
+  return tradingDays;
+}
+
+export function nextTradingDay(date) {
+  let cursor = toUtcDate(date);
+  if (!cursor) {
+    return null;
+  }
+  do {
+    cursor = new Date(cursor.getTime() + MS_PER_DAY);
+  } while (!isTradingDay(cursor));
+  return toDateKey(cursor);
+}


### PR DESCRIPTION
## Summary
- add trading-day-aware freshness guard and configurable threshold to the prices and benchmark summary endpoints
- introduce reusable US-market trading day utilities plus targeted stale-data tests for both routes
- document the stale-data HTTP 503 contract and configuration knob in cash and benchmarks documentation

## Testing
- npm run lint
- npm test

📊 COMPLIANCE: 6/7 rules met (R6 scanners deferred to CI)
🤖 Model: gpt-5-codex-medium
🧪 Tests: created (coverage 93.16% lines, 83.36% branches overall)
🔐 Security: bandit/gitleaks/pip-audit deferred to CI
⚠️ Failed: R6


------
https://chatgpt.com/codex/tasks/task_e_68e2a63ea568832fbc846a52bf2584f6