### PR TITLE
Add ledger property test harness

### DIFF
--- a/docs/HARDENING_SCOREBOARD.md
+++ b/docs/HARDENING_SCOREBOARD.md
@@ -29,7 +29,7 @@
 | PERF-3  | UI virtualization/pagination     | LOW      |       | TODO         |                   |    |               |
 | PERF-4  | DB migration trigger             | LOW→MED  |       | TODO         |                   |    |               |
 | TEST-1  | Unit tests                       | HIGH     |       | TODO         |                   |    |               |
-| TEST-2  | Property-based tests             | HIGH     |       | TODO         |                   |    |               |
+| TEST-2  | Property-based tests             | HIGH     |       | DONE         | feat/ledger-property-tests | PR pending | Randomized ledger invariants (cash floors, share conservation, deterministic TWR)
 | TEST-3  | Golden snapshot tests            | HIGH     |       | TODO         |                   |    |               |
 | TEST-4  | Concurrency tests                | HIGH     |       | TODO         |                   |    |               |
 | TEST-5  | API contract tests               | HIGH     |       | TODO         |                   |    |               |

--- a/docs/cash-benchmarks.md
+++ b/docs/cash-benchmarks.md
@@ -99,6 +99,7 @@ Price- and benchmark-derived responses enforce a trading-day-aware freshness thr
 
 - Unit coverage: cash accrual, return math, and SPY track parity (`server/__tests__/cash.test.js`, `server/__tests__/returns.test.js`).
 - Integration coverage: nightly job idempotency and API exposure (`server/__tests__/daily_close.test.js`).
+- Property coverage: randomized ledger stress harness validating cash floors, share conservation, and deterministic return rows (`server/__tests__/ledger.property.test.js`).
 
 ## TODO
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,6 +32,7 @@
         "@vitejs/plugin-react": "^4.0.0",
         "autoprefixer": "^10.4.15",
         "eslint": "^9.11.1",
+        "fast-check": "^3.23.2",
         "gitleaks": "file:tools/gitleaks",
         "globals": "^15.9.0",
         "jsdom": "^24.0.0",
@@ -3387,6 +3388,29 @@
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "license": "MIT"
     },
+    "node_modules/fast-check": {
+      "version": "3.23.2",
+      "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-3.23.2.tgz",
+      "integrity": "sha512-h5+1OzzfCC3Ef7VbtKdcv7zsstUQwUDlYpUTvjeUsJAssPgLn7QzbboPtL5ro04Mq0rPOsMzl7q5hIbRs2wD1A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "pure-rand": "^6.1.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -5576,6 +5600,23 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/pure-rand": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-6.1.0.tgz",
+      "integrity": "sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/qs": {
       "version": "6.13.0",

--- a/package.json
+++ b/package.json
@@ -37,14 +37,15 @@
     "@vitejs/plugin-react": "^4.0.0",
     "autoprefixer": "^10.4.15",
     "eslint": "^9.11.1",
+    "fast-check": "^3.23.2",
+    "gitleaks": "file:tools/gitleaks",
     "globals": "^15.9.0",
     "jsdom": "^24.0.0",
     "postcss": "^8.4.33",
     "prettier": "^3.2.5",
     "supertest": "^7.0.0",
     "tailwindcss": "^3.3.5",
-    "vite": "^5.0.0",
-    "gitleaks": "file:tools/gitleaks"
+    "vite": "^5.0.0"
   },
   "type": "module"
 }

--- a/server/__tests__/ledger.property.test.js
+++ b/server/__tests__/ledger.property.test.js
@@ -1,0 +1,289 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import fc from 'fast-check';
+
+import { toDateKey } from '../finance/cash.js';
+import {
+  computeDailyStates,
+  sortTransactions,
+} from '../finance/portfolio.js';
+import { computeDailyReturnRows } from '../finance/returns.js';
+import {
+  d,
+  fromCents,
+  fromMicroShares,
+  toCents,
+  toMicroShares,
+} from '../finance/decimal.js';
+
+const DAY_MS = 86_400_000;
+const TICKERS = ['SPY', 'QQQ', 'IWM'];
+
+const dayPlanArb = fc.record({
+  deposit: fc.double({ min: 0, max: 20000, noNaN: true }),
+  withdrawFraction: fc.double({ min: 0, max: 1, noNaN: true }),
+  prices: fc.array(fc.double({ min: 5, max: 750, noNaN: true }), {
+    minLength: TICKERS.length,
+    maxLength: TICKERS.length,
+  }),
+  buyInstructions: fc.array(
+    fc.record({
+      tickerIndex: fc.integer({ min: 0, max: TICKERS.length - 1 }),
+      fraction: fc.double({ min: 0, max: 0.6, noNaN: true }),
+    }),
+    { maxLength: 4 },
+  ),
+  sellInstructions: fc.array(
+    fc.record({
+      tickerIndex: fc.integer({ min: 0, max: TICKERS.length - 1 }),
+      fraction: fc.double({ min: 0, max: 1, noNaN: true }),
+    }),
+    { maxLength: 4 },
+  ),
+});
+
+const ledgerPlanArb = fc.array(dayPlanArb, { minLength: 5, maxLength: 20 });
+
+const ratePlanArb = fc.array(
+  fc.record({
+    offset: fc.integer({ min: 0, max: 30 }),
+    apy: fc.double({ min: 0, max: 0.12, noNaN: true }),
+  }),
+  { minLength: 1, maxLength: 6 },
+);
+
+function dateKeyFromOffset(baseDate, offset) {
+  return toDateKey(new Date(baseDate.getTime() + offset * DAY_MS));
+}
+
+function toPriceMap(prices) {
+  const map = new Map();
+  for (let i = 0; i < TICKERS.length; i += 1) {
+    const ticker = TICKERS[i];
+    const price = Number.parseFloat(prices[i]?.toFixed(4) ?? '0');
+    map.set(ticker, Number.isFinite(price) && price > 0 ? price : 100);
+  }
+  return map;
+}
+
+test('ledger transactions preserve invariants under random scenarios', async () => {
+  await fc.assert(
+    fc.property(ledgerPlanArb, ratePlanArb, (plans, ratePlans) => {
+      const baseDate = new Date('2024-01-01T00:00:00Z');
+      const dates = plans.map((_, index) => dateKeyFromOffset(baseDate, index));
+
+      const pricesByDate = new Map();
+      for (let i = 0; i < plans.length; i += 1) {
+        pricesByDate.set(dates[i], toPriceMap(plans[i].prices));
+      }
+
+      const transactions = [];
+      const holdingsMicro = new Map(TICKERS.map((ticker) => [ticker, 0]));
+      let cashCents = 0;
+
+      for (let dayIndex = 0; dayIndex < plans.length; dayIndex += 1) {
+        const plan = plans[dayIndex];
+        const date = dates[dayIndex];
+        const prices = pricesByDate.get(date) ?? new Map();
+
+        if (dayIndex === 0) {
+          const seedDepositCents = toCents(10000);
+          cashCents += seedDepositCents;
+          transactions.push({
+            id: `seed-${date}`,
+            date,
+            type: 'DEPOSIT',
+            amount: fromCents(seedDepositCents).toNumber(),
+          });
+        }
+
+        const depositCents = toCents(plan.deposit);
+        if (depositCents > 0) {
+          cashCents += depositCents;
+          transactions.push({
+            id: `deposit-${date}-${depositCents}`,
+            date,
+            type: 'DEPOSIT',
+            amount: fromCents(depositCents).toNumber(),
+          });
+        }
+
+        for (const instruction of plan.buyInstructions) {
+          if (cashCents <= 0) {
+            break;
+          }
+          const ticker = TICKERS[instruction.tickerIndex];
+          const priceValue = prices.get(ticker) ?? 0;
+          const price = d(priceValue);
+          if (!price.isFinite() || price.lte(0)) {
+            continue;
+          }
+
+          const availableQuantityMicro = Math.floor(
+            d(cashCents)
+              .div(100)
+              .div(price)
+              .times(1_000_000)
+              .toNumber(),
+          );
+          if (availableQuantityMicro <= 0) {
+            continue;
+          }
+
+          const quantityMicro = Math.floor(
+            availableQuantityMicro * Math.min(1, instruction.fraction),
+          );
+          if (quantityMicro <= 0) {
+            continue;
+          }
+
+          const quantity = fromMicroShares(quantityMicro);
+          const amountCents = toCents(quantity.times(price));
+          if (amountCents <= 0 || amountCents > cashCents) {
+            continue;
+          }
+
+          transactions.push({
+            id: `buy-${date}-${ticker}-${quantityMicro}`,
+            date,
+            type: 'BUY',
+            ticker,
+            quantity: quantity.toNumber(),
+            amount: fromCents(amountCents).toNumber(),
+          });
+          cashCents -= amountCents;
+          holdingsMicro.set(
+            ticker,
+            (holdingsMicro.get(ticker) ?? 0) + quantityMicro,
+          );
+        }
+
+        for (const instruction of plan.sellInstructions) {
+          const ticker = TICKERS[instruction.tickerIndex];
+          const ownedMicro = holdingsMicro.get(ticker) ?? 0;
+          if (ownedMicro <= 0) {
+            continue;
+          }
+          const priceValue = prices.get(ticker) ?? 0;
+          const price = d(priceValue);
+          if (!price.isFinite() || price.lte(0)) {
+            continue;
+          }
+
+          const quantityMicro = Math.floor(ownedMicro * Math.min(1, instruction.fraction));
+          if (quantityMicro <= 0) {
+            continue;
+          }
+
+          const quantity = fromMicroShares(quantityMicro);
+          const amountCents = toCents(quantity.times(price));
+          if (amountCents <= 0) {
+            continue;
+          }
+
+          transactions.push({
+            id: `sell-${date}-${ticker}-${quantityMicro}`,
+            date,
+            type: 'SELL',
+            ticker,
+            quantity: -quantity.toNumber(),
+            amount: fromCents(amountCents).toNumber(),
+          });
+          cashCents += amountCents;
+          holdingsMicro.set(ticker, ownedMicro - quantityMicro);
+        }
+
+        const withdrawCents = Math.min(
+          cashCents,
+          Math.floor(cashCents * Math.min(1, plan.withdrawFraction)),
+        );
+        if (withdrawCents > 0) {
+          cashCents -= withdrawCents;
+          transactions.push({
+            id: `withdraw-${date}-${withdrawCents}`,
+            date,
+            type: 'WITHDRAWAL',
+            amount: fromCents(withdrawCents).toNumber(),
+          });
+        }
+      }
+
+      const sortedTransactions = sortTransactions(transactions);
+      const states = computeDailyStates({
+        transactions: sortedTransactions,
+        pricesByDate,
+        dates,
+      });
+
+      assert.ok(states.length === dates.length);
+
+      const finalState = states.at(-1);
+      assert.ok(finalState, 'final state missing');
+
+      for (const ticker of TICKERS) {
+        const expectedMicro = holdingsMicro.get(ticker) ?? 0;
+        const actualQty = finalState.holdings.get(ticker) ?? 0;
+        const actualMicro = toMicroShares(actualQty);
+        assert.ok(
+          Math.abs(actualMicro - expectedMicro) <= 2,
+          `share imbalance for ${ticker}`,
+        );
+      }
+
+      for (const state of states) {
+        assert.ok(
+          state.cash >= -0.01,
+          `cash dipped negative on ${state.date}: ${state.cash}`,
+        );
+      }
+
+      const spyPrices = new Map();
+      for (const [date, priceMap] of pricesByDate.entries()) {
+        spyPrices.set(date, priceMap.get('SPY') ?? 100);
+      }
+
+      const rateEntries = new Map();
+      rateEntries.set(dates[0], 0);
+      for (const entry of ratePlans) {
+        const effectiveDate = dateKeyFromOffset(
+          baseDate,
+          Math.min(entry.offset, plans.length - 1),
+        );
+        const apy = Number.parseFloat(entry.apy.toFixed(6));
+        rateEntries.set(effectiveDate, apy >= 0 ? apy : 0);
+      }
+      const rates = Array.from(rateEntries.entries())
+        .sort((a, b) => a[0].localeCompare(b[0]))
+        .map(([effective_date, apy]) => ({ effective_date, apy }));
+
+      const rows = computeDailyReturnRows({
+        states,
+        rates,
+        spyPrices,
+        transactions: sortedTransactions,
+      });
+      assert.equal(rows.length, states.length);
+
+      const serializedStates = states.map((state) => ({
+        ...state,
+        holdings: Object.fromEntries(state.holdings.entries()),
+      }));
+
+      const rehydratedStates = serializedStates.map((state) => ({
+        ...state,
+        holdings: new Map(Object.entries(state.holdings)),
+      }));
+
+      const rowsReloaded = computeDailyReturnRows({
+        states: rehydratedStates,
+        rates,
+        spyPrices,
+        transactions: sortedTransactions,
+      });
+
+      assert.deepEqual(rowsReloaded, rows);
+    }),
+    { numRuns: 50 },
+  );
+});


### PR DESCRIPTION
## Summary
- add fast-check dev dependency and property-based ledger invariant suite exercising randomized ledgers
- document the new property coverage in the cash benchmarks guide and mark TEST-2 complete on the hardening scoreboard

## Testing
- `npm run lint`
- `npm test -- --test-name-pattern=ledger`

📊 COMPLIANCE: 6/7 rules met (Missing: R2 scanners deferred to CI)
🤖 Model: gpt-5-codex-medium
🧪 Tests: created (property) + coverage from node --test
🔐 Security: bandit n/a, gitleaks deferred, pip-audit deferred
⚠️ Failed: R2


------
https://chatgpt.com/codex/tasks/task_e_68e2b073085c832fb46ffc4d43818897