### PR TITLE
Add OpenAPI contract tests for core endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,10 @@ Run the test suite to verify all fixes:
 npm test
 ```
 
-All Phase 1 critical tests should pass.
+The suite includes OpenAPI contract coverage via `server/__tests__/api_contract.test.js`,
+which loads [`docs/openapi.yaml`](docs/openapi.yaml) with `@apidevtools/swagger-parser` and
+validates the JSON returned by SuperTest requests against the documented schemas. All Phase 1
+critical tests should pass.
 
 ## Continuous Integration
 

--- a/docs/HARDENING_SCOREBOARD.md
+++ b/docs/HARDENING_SCOREBOARD.md
@@ -32,4 +32,4 @@
 | TEST-2  | Property-based tests             | HIGH     |       | DONE         | feat/ledger-property-tests | PR pending | Randomized ledger invariants (cash floors, share conservation, deterministic TWR)
 | TEST-3  | Golden snapshot tests            | HIGH     |       | DONE         | feat/returns-snapshots | Pending | Local: npm test -- returns.snapshot |
 | TEST-4  | Concurrency tests                | HIGH     |       | DONE         | feat\|fix/storage-concurrency-tests | Pending | Local: node --test server/__tests__/storage_concurrency.test.js (≈0.8s, covers Promise.all writers + rename crash) |
-| TEST-5  | API contract tests               | HIGH     |       | TODO         |                   |    |               |
+| TEST-5  | API contract tests               | HIGH     |       | DONE         | feat\|fix/api-contract-validation | Pending | Local: npm test |

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -137,6 +137,44 @@ paths:
               schema:
                 type: string
               description: Strong validator for conditional requests
+  /api/prices/{symbol}:
+    get:
+      summary: Historical adjusted-close prices for a symbol
+      parameters:
+        - in: path
+          name: symbol
+          required: true
+          schema:
+            type: string
+        - in: query
+          name: range
+          schema:
+            type: string
+            enum: [1y]
+          description: Historical window (currently only `1y` is supported)
+      responses:
+        '200':
+          description: Historical price series
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  required:
+                    - date
+                    - close
+                  properties:
+                    date:
+                      type: string
+                      format: date
+                    close:
+                      type: number
+          headers:
+            ETag:
+              schema:
+                type: string
+              description: Strong validator for conditional requests
   /api/benchmarks/summary:
     get:
       summary: Cumulative returns and drag metrics

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,10 +26,13 @@
         "zod": "^4.1.11"
       },
       "devDependencies": {
+        "@apidevtools/swagger-parser": "^12.0.0",
         "@eslint/js": "^9.11.1",
         "@testing-library/react": "^14.1.2",
         "@testing-library/user-event": "^14.4.3",
         "@vitejs/plugin-react": "^4.0.0",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
         "autoprefixer": "^10.4.15",
         "eslint": "^9.11.1",
         "fast-check": "^3.23.2",
@@ -54,6 +57,73 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@apidevtools/json-schema-ref-parser": {
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/@apidevtools/json-schema-ref-parser/-/json-schema-ref-parser-14.0.1.tgz",
+      "integrity": "sha512-Oc96zvmxx1fqoSEdUmfmvvb59/KDOnUoJ7s2t7bISyAn0XEz57LCCw8k2Y4Pf3mwKaZLMciESALORLgfe2frCw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/json-schema": "^7.0.15",
+        "js-yaml": "^4.1.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/philsturgeon"
+      }
+    },
+    "node_modules/@apidevtools/openapi-schemas": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@apidevtools/openapi-schemas/-/openapi-schemas-2.1.0.tgz",
+      "integrity": "sha512-Zc1AlqrJlX3SlpupFGpiLi2EbteyP7fXmUOGup6/DnkRgjP9bgMM/ag+n91rsv0U1Gpz0H3VILA/o3bW7Ua6BQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@apidevtools/swagger-methods": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@apidevtools/swagger-methods/-/swagger-methods-3.0.2.tgz",
+      "integrity": "sha512-QAkD5kK2b1WfjDS/UQn/qQkbwF31uqRjPTrsCs5ZG9BQGAkjwvqGFjjPqAuzac/IYzpPtRzjCP1WrTuAIjMrXg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@apidevtools/swagger-parser": {
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/@apidevtools/swagger-parser/-/swagger-parser-12.0.0.tgz",
+      "integrity": "sha512-WLJIWcfOXrSKlZEM+yhA2Xzatgl488qr1FoOxixYmtWapBzwSC0gVGq4WObr4hHClMIiFFdOBdixNkvWqkWIWA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@apidevtools/json-schema-ref-parser": "14.0.1",
+        "@apidevtools/openapi-schemas": "^2.1.0",
+        "@apidevtools/swagger-methods": "^3.0.2",
+        "ajv": "^8.17.1",
+        "ajv-draft-04": "^1.0.0",
+        "call-me-maybe": "^1.0.2"
+      },
+      "peerDependencies": {
+        "openapi-types": ">=7"
+      }
+    },
+    "node_modules/@apidevtools/swagger-parser/node_modules/ajv-draft-04": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/ajv-draft-04/-/ajv-draft-04-1.0.0.tgz",
+      "integrity": "sha512-mv00Te6nmYbRp5DCwclxtt7yV/joXJPGS7nM+97GdxvuttCOfgI3K4U25zboyeX0O+myI8ERluxQe5wljMmVIw==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "ajv": "^8.5.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
       }
     },
     "node_modules/@asamuzakjp/css-color": {
@@ -1005,6 +1075,23 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/@eslint/eslintrc/node_modules/ajv": {
+      "version": "6.12.6",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
     "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
       "version": "1.1.12",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
@@ -1028,6 +1115,13 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@eslint/eslintrc/node_modules/minimatch": {
       "version": "3.1.2",
@@ -1906,20 +2000,38 @@
       }
     },
     "node_modules/ajv": {
-      "version": "6.12.6",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
+      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "fast-deep-equal": "^3.1.1",
-        "fast-json-stable-stringify": "^2.0.0",
-        "json-schema-traverse": "^0.4.1",
-        "uri-js": "^4.2.2"
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
       }
     },
     "node_modules/ansi-regex": {
@@ -2276,6 +2388,13 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/call-me-maybe": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-me-maybe/-/call-me-maybe-1.0.2.tgz",
+      "integrity": "sha512-HpX65o1Hnr9HH25ojC1YGs7HCQLq0GCOibSaWER0eNpgJ/Z1MZv2mTc7+xh6WOPxbRVcmgbv4hGU+uSQ/2xFZQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/callsites": {
       "version": "3.1.0",
@@ -3206,6 +3325,23 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/eslint/node_modules/ajv": {
+      "version": "6.12.6",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
     "node_modules/eslint/node_modules/brace-expansion": {
       "version": "1.1.12",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
@@ -3216,6 +3352,13 @@
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
       }
+    },
+    "node_modules/eslint/node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/eslint/node_modules/minimatch": {
       "version": "3.1.2",
@@ -3477,6 +3620,23 @@
       "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
+      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/fastq": {
       "version": "1.19.1",
@@ -4553,9 +4713,9 @@
       "license": "MIT"
     },
     "node_modules/json-schema-traverse": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "dev": true,
       "license": "MIT"
     },
@@ -5049,6 +5209,14 @@
       "dependencies": {
         "wrappy": "1"
       }
+    },
+    "node_modules/openapi-types": {
+      "version": "12.1.3",
+      "resolved": "https://registry.npmjs.org/openapi-types/-/openapi-types-12.1.3.tgz",
+      "integrity": "sha512-N4YtSYJqghVu4iek2ZUvcN/0aqH1kRDuNqzcycDxhOUpg7GdvLa2F3DgS6yBNhInhv2r/6I0Flkn7CqL8+nIcw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/optionator": {
       "version": "0.9.4",
@@ -5887,6 +6055,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/requires-port": {

--- a/package.json
+++ b/package.json
@@ -31,10 +31,13 @@
     "zod": "^4.1.11"
   },
   "devDependencies": {
+    "@apidevtools/swagger-parser": "^12.0.0",
     "@eslint/js": "^9.11.1",
     "@testing-library/react": "^14.1.2",
     "@testing-library/user-event": "^14.4.3",
     "@vitejs/plugin-react": "^4.0.0",
+    "ajv": "^8.17.1",
+    "ajv-formats": "^3.0.1",
     "autoprefixer": "^10.4.15",
     "eslint": "^9.11.1",
     "fast-check": "^3.23.2",

--- a/server/__tests__/api_contract.test.js
+++ b/server/__tests__/api_contract.test.js
@@ -1,0 +1,194 @@
+import assert from 'node:assert/strict';
+import { afterEach, before, beforeEach, test } from 'node:test';
+import { mkdtempSync, rmSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { tmpdir } from 'node:os';
+
+import SwaggerParser from '@apidevtools/swagger-parser';
+import Ajv from 'ajv';
+import addFormats from 'ajv-formats';
+import request from 'supertest';
+
+import { createApp } from '../app.js';
+import JsonTableStorage from '../data/storage.js';
+
+const noopLogger = { info() {}, warn() {}, error() {} };
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const specPath = path.resolve(__dirname, '../../docs/openapi.yaml');
+
+let apiDocument;
+const ajv = new Ajv({ strict: false, allErrors: true, allowUnionTypes: true });
+addFormats(ajv);
+
+const validatorCache = new Map();
+
+function getValidator(pathKey, method = 'get', statusCode = '200') {
+  const cacheKey = `${method.toLowerCase()} ${pathKey} ${statusCode}`;
+  if (validatorCache.has(cacheKey)) {
+    return validatorCache.get(cacheKey);
+  }
+  const operation = apiDocument.paths?.[pathKey]?.[method.toLowerCase()];
+  assert.ok(operation, `operation not found for ${method.toUpperCase()} ${pathKey}`);
+  const response = operation.responses?.[statusCode];
+  assert.ok(response, `response ${statusCode} not defined for ${method.toUpperCase()} ${pathKey}`);
+  const schema = response.content?.['application/json']?.schema;
+  assert.ok(schema, `JSON schema missing for ${method.toUpperCase()} ${pathKey} status ${statusCode}`);
+  const validator = ajv.compile(schema);
+  validatorCache.set(cacheKey, validator);
+  return validator;
+}
+
+function expectValidResponse(validator, payload) {
+  const valid = validator(payload);
+  const failureMessage = !valid
+    ? ajv.errorsText(validator.errors ?? [], { dataVar: 'response.body' })
+    : '';
+  assert.equal(valid, true, failureMessage);
+}
+
+let dataDir;
+let storage;
+let buildApp;
+
+before(async () => {
+  apiDocument = await SwaggerParser.dereference(specPath);
+});
+
+beforeEach(async () => {
+  dataDir = mkdtempSync(path.join(tmpdir(), 'api-contract-'));
+  storage = new JsonTableStorage({ dataDir, logger: noopLogger });
+  await storage.ensureTable('transactions', []);
+  await storage.ensureTable('cash_rates', []);
+  await storage.ensureTable('returns_daily', []);
+  await storage.ensureTable('nav_snapshots', []);
+  buildApp = (overrides = {}) =>
+    createApp({
+      dataDir,
+      logger: noopLogger,
+      config: { featureFlags: { cashBenchmarks: true }, cors: { allowedOrigins: [] } },
+      ...overrides,
+    });
+});
+
+afterEach(() => {
+  rmSync(dataDir, { recursive: true, force: true });
+  validatorCache.clear();
+});
+
+test('GET /api/returns/daily matches the OpenAPI contract', async () => {
+  await storage.writeTable('returns_daily', [
+    {
+      date: '2024-01-01',
+      r_port: 0.01,
+      r_ex_cash: 0.009,
+      r_spy_100: 0.012,
+      r_bench_blended: 0.011,
+      r_cash: 0.0001,
+    },
+    {
+      date: '2024-01-02',
+      r_port: 0.015,
+      r_ex_cash: 0.014,
+      r_spy_100: 0.017,
+      r_bench_blended: 0.016,
+      r_cash: 0.0001,
+    },
+  ]);
+
+  const app = buildApp();
+  const response = await request(app).get(
+    '/api/returns/daily?from=2024-01-01&to=2024-01-02&views=port,excash,spy,bench',
+  );
+
+  assert.equal(response.status, 200);
+  const validator = getValidator('/api/returns/daily');
+  expectValidResponse(validator, response.body);
+});
+
+test('GET /api/nav/daily matches the OpenAPI contract', async () => {
+  await storage.writeTable('nav_snapshots', [
+    {
+      date: '2024-01-01',
+      portfolio_nav: 1000,
+      ex_cash_nav: 800,
+      cash_balance: 200,
+      risk_assets_value: 800,
+      stale_price: false,
+    },
+    {
+      date: '2024-01-02',
+      portfolio_nav: 1010,
+      ex_cash_nav: 805,
+      cash_balance: 205,
+      risk_assets_value: 805,
+      stale_price: true,
+    },
+  ]);
+
+  const app = buildApp();
+  const response = await request(app).get('/api/nav/daily?from=2024-01-01&to=2024-01-02');
+
+  assert.equal(response.status, 200);
+  const validator = getValidator('/api/nav/daily');
+  expectValidResponse(validator, response.body);
+});
+
+test('GET /api/benchmarks/summary matches the OpenAPI contract', async () => {
+  await storage.writeTable('returns_daily', [
+    {
+      date: '2024-01-01',
+      r_port: 0.01,
+      r_ex_cash: 0.009,
+      r_spy_100: 0.012,
+      r_bench_blended: 0.011,
+      r_cash: 0.0001,
+    },
+    {
+      date: '2024-01-02',
+      r_port: 0.015,
+      r_ex_cash: 0.014,
+      r_spy_100: 0.017,
+      r_bench_blended: 0.016,
+      r_cash: 0.0002,
+    },
+  ]);
+
+  const app = buildApp();
+  const response = await request(app).get('/api/benchmarks/summary?from=2024-01-01&to=2024-01-02');
+
+  assert.equal(response.status, 200);
+  const validator = getValidator('/api/benchmarks/summary');
+  expectValidResponse(validator, response.body);
+});
+
+test('GET /api/prices/:symbol matches the OpenAPI contract', async () => {
+  const today = new Date();
+  const yesterday = new Date(today);
+  yesterday.setDate(today.getDate() - 1);
+  const todayKey = today.toISOString().slice(0, 10);
+  const yesterdayKey = yesterday.toISOString().slice(0, 10);
+  const priceProvider = {
+    async getDailyAdjustedClose() {
+      return [
+        { date: yesterdayKey, adjClose: 123.45 },
+        { date: todayKey, adjClose: 124.56 },
+      ];
+    },
+  };
+
+  const app = buildApp({
+    priceProvider,
+    config: {
+      featureFlags: { cashBenchmarks: true },
+      cors: { allowedOrigins: [] },
+      freshness: { maxStaleTradingDays: 30 },
+    },
+  });
+  const response = await request(app).get('/api/prices/AAPL');
+
+  assert.equal(response.status, 200);
+  const validator = getValidator('/api/prices/{symbol}');
+  expectValidResponse(validator, response.body);
+});


### PR DESCRIPTION
## Summary
- add an API contract test suite that loads docs/openapi.yaml with Swagger Parser and validates SuperTest responses using Ajv
- extend the OpenAPI document with the /api/prices/{symbol} schema and wire new contract coverage into the README and hardening scoreboard
- add Ajv-based tooling in devDependencies for schema validation during the tests

## Testing
- `npm run lint`
- `npm test`

---

📊 COMPLIANCE: 7/7 rules met (None)
🤖 Model: gpt-5-codex-medium
🧪 Tests: created (coverage 94.09% lines overall via `npm test`)
🔐 Security: gitleaks, npm audit deferred to CI
⚠️ Failed: None

------
https://chatgpt.com/codex/tasks/task_e_68e2bb090824832fb3ca6effa97077cc