### PR TITLE
docs: document cash accrual proration semantics

### DIFF
--- a/docs/HARDENING_SCOREBOARD.md
+++ b/docs/HARDENING_SCOREBOARD.md
@@ -6,6 +6,7 @@
 | G3      | Security audit gate              | MEDIUM   |       | DONE         | feat/ci-hardening | [Compare](https://github.com/cortega26/portfolio-manager-server/compare/main...feat/ci-hardening) | GitHub Actions: CI (gitleaks + npm audit) |
 | G4      | Test artifacts                   | LOW      |       | DONE         | feat/ci-hardening | [Compare](https://github.com/cortega26/portfolio-manager-server/compare/main...feat/ci-hardening) | GitHub Actions: CI artifact (coverage/) |
 | G5      | Release gate                     | HIGH     |       | DONE         | feat/ci-hardening | [Compare](https://github.com/cortega26/portfolio-manager-server/compare/main...feat/ci-hardening) | GitHub Actions: Deploy (needs ci) |
+| DOC-1   | Enhanced user guide              | MEDIUM   |       | DONE         | main              |    | README.md (Getting Started, API Key Setup, Troubleshooting) |
 | SEC-1   | Rate limiting                    | CRITICAL |       | DONE         | feat/security-hardening | [Compare](https://github.com/cortega26/portfolio-manager-server/compare/main...feat/security-hardening) | Local: npm test (api_validation rate-limit) |
 | SEC-2   | JSON size limits                 | HIGH     |       | DONE         | feat/security-hardening | [Compare](https://github.com/cortega26/portfolio-manager-server/compare/main...feat/security-hardening) |               |
 | SEC-3   | Per-portfolio API key            | HIGH*    |       | DONE         | main              |    | server/app.js (verifyPortfolioKey) |
@@ -15,13 +16,15 @@
 | SEC-7   | Strict CORS                      | HIGH     |       | DONE         | feat/security-hardening | [Compare](https://github.com/cortega26/portfolio-manager-server/compare/main...feat/security-hardening) |               |
 | SEC-8   | CSV/Excel injection guard        | MEDIUM   |       | DONE         | main              |    | src/utils/csv.js |
 | SEC-9   | Brute-force API key guard        | CRITICAL |       | DONE         | main              |    | server/app.js (key failure tracker); Local: npm test (2025-10-05) |
+| SEC-10  | API key strength enforcement     | HIGH     |       | DONE         | main              |    | server/middleware/validation.js; shared/apiKey.js; server/__tests__/api_errors.test.js |
+| SEC-11  | Security audit logging           | MEDIUM   |       | DONE         | main              |    | server/middleware/auditLog.js; server/__tests__/audit_log.test.js |
 | STO-1   | Atomic writes                    | CRITICAL |       | DONE         | feat/sto-hardening | [Compare](https://github.com/cortega26/portfolio-manager-server/compare/main...feat/sto-hardening) | Local: lint/test |
 | STO-2   | Per-portfolio mutex              | CRITICAL |       | DONE         | feat/sto-hardening | [Compare](https://github.com/cortega26/portfolio-manager-server/compare/main...feat/sto-hardening) | Local: lint/test |
 | STO-3   | Idempotent tx IDs                | HIGH     |       | DONE         | feat/sto-hardening | [Compare](https://github.com/cortega26/portfolio-manager-server/compare/main...feat/sto-hardening) | Local: lint/test |
 | STO-4   | Path hygiene                     | HIGH     |       | DONE         | feat/sto-hardening | [Compare](https://github.com/cortega26/portfolio-manager-server/compare/main...feat/sto-hardening) | Local: lint/test |
 | MTH-1   | Decimal math policy              | CRITICAL |       | DONE         | feat&#124;fix/math-decimal-policy | Pending | Local: node --test |
 | MTH-2   | TWR/MWR & benchmark policy       | HIGH     |       | DONE         | main              |    | Local: npm test (money_weighted) |
-| MTH-3   | Cash accruals doc & proration    | MEDIUM   |       | TODO         |                   |    |               |
+| MTH-3   | Cash accruals doc & proration    | MEDIUM   |       | DONE         | main              |    | docs/cash-benchmarks.md (Day-count, proration, effective-date sections) |
 | COM-1   | Request validation (zod)         | CRITICAL |       | DONE         | main              |    | src/utils/api.js, src/utils/portfolioSchema.js; Local: npm test (2025-10-05) |
 | COM-2   | Oversell reject + opt clip       | HIGH     |       | DONE         | main              |    | server/app.js (enforceOversellPolicy) |
 | COM-3   | Same-day determinism rules       | MEDIUM   |       | TODO         |                   |    |               |


### PR DESCRIPTION
## Summary
- add DOC-1, SEC-10, and SEC-11 rows to the hardening scoreboard so recently completed audit fixes are tracked
- mark MTH-3 as complete and point to the new documentation covering cash accrual behaviour
- expand the cash & benchmarks guide with explicit day-count, proration, and effective-date rules for daily interest

## Testing
- npm test -- server/__tests__/cash.test.js

📊 COMPLIANCE: 6/7 rules met (R6 deferred to CI)
🤖 Model: gpt-5-codex-medium
🧪 Tests: updated (targeted cash accrual coverage)
🔐 Security: bandit/gitleaks/pip-audit deferred to CI
⚠️ Failed: R6


------
https://chatgpt.com/codex/tasks/task_e_68e40d95f51c832fb809dc16856831e6