### PR TITLE
feat: add incremental holdings ledger

### DIFF
--- a/docs/HARDENING_SCOREBOARD.md
+++ b/docs/HARDENING_SCOREBOARD.md
@@ -32,7 +32,7 @@
 | DX-1    | Transactions form reducer        | MEDIUM   |       | DONE         | main              |    | src/components/TransactionsTab.jsx; Local: npm test (2025-10-05) |
 | DX-2    | Environment template             | LOW      |       | DONE         | main              |    | `.env.example` committed; README "Environment configuration" section |
 | PERF-1  | Price caching + stale guard      | HIGH     |       | DONE         | feat\|fix/cache-etag-cache | Local: node --test cache_behaviors; Phase2 Item1 tests (`server/__tests__/api_cache.test.js`) |               |
-| PERF-2  | Incremental holdings             | MEDIUM   |       | TODO         |                   |    |               |
+| PERF-2  | Incremental holdings             | MEDIUM   |       | DONE         | feat/perf-incremental-holdings | [Compare](https://github.com/cortega26/portfolio-manager-server/compare/main...feat/perf-incremental-holdings) | Local: npm test (storage concurrency failing pre-existing) |
 | PERF-3  | UI virtualization/pagination     | LOW      |       | TODO         |                   |    |               |
 | PERF-4  | DB migration trigger             | LOW→MED  |       | TODO         |                   |    |               |
 | PERF-5  | Response compression             | MEDIUM   |       | DONE         | main              |    | `server/__tests__/compression.test.js` (Phase2 Item3) |

--- a/src/__tests__/holdings_ledger.test.js
+++ b/src/__tests__/holdings_ledger.test.js
@@ -1,0 +1,78 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+import { buildHoldings } from "../utils/holdings.js";
+import {
+  buildLedgerFromTransactions,
+  createInitialLedgerState,
+  ledgerReducer,
+} from "../utils/holdingsLedger.js";
+
+const SAMPLE_TRANSACTIONS = [
+  { ticker: "AAPL", type: "BUY", shares: 5, amount: -500, date: "2024-01-02" },
+  { ticker: "AAPL", type: "BUY", shares: 3, amount: -360, date: "2024-01-05" },
+  { ticker: "AAPL", type: "SELL", shares: 4, amount: 460, date: "2024-01-10" },
+  { ticker: "MSFT", type: "BUY", shares: 2, amount: -420, date: "2024-01-12" },
+];
+
+describe("holdings ledger reducer", () => {
+  it("builds ledger state equivalent to full holdings rebuild", () => {
+    const ledger = buildLedgerFromTransactions(SAMPLE_TRANSACTIONS, { logSummary: false });
+    const expectedHoldings = buildHoldings(SAMPLE_TRANSACTIONS);
+
+    assert.equal(ledger.transactions.length, SAMPLE_TRANSACTIONS.length);
+    assert.equal(ledger.history.length, SAMPLE_TRANSACTIONS.length);
+    assert.deepEqual(ledger.holdings, expectedHoldings);
+  });
+
+  it("appends transactions incrementally", () => {
+    const seedTransactions = SAMPLE_TRANSACTIONS.slice(0, 2);
+    let state = buildLedgerFromTransactions(seedTransactions, { logSummary: false });
+
+    state = ledgerReducer(state, {
+      type: "append",
+      transaction: SAMPLE_TRANSACTIONS[2],
+    });
+
+    const expectedHoldings = buildHoldings(SAMPLE_TRANSACTIONS.slice(0, 3));
+    assert.deepEqual(state.holdings, expectedHoldings);
+    assert.equal(state.transactions.length, 3);
+  });
+
+  it("removes the most recent transaction using history snapshots", () => {
+    let state = buildLedgerFromTransactions(SAMPLE_TRANSACTIONS, { logSummary: false });
+
+    state = ledgerReducer(state, {
+      type: "remove",
+      index: SAMPLE_TRANSACTIONS.length - 1,
+    });
+
+    const expectedTransactions = SAMPLE_TRANSACTIONS.slice(0, -1);
+    const expectedHoldings = buildHoldings(expectedTransactions);
+
+    assert.deepEqual(state.holdings, expectedHoldings);
+    assert.equal(state.transactions.length, expectedTransactions.length);
+  });
+
+  it("rebuilds when removing non-terminal transactions", () => {
+    let state = buildLedgerFromTransactions(SAMPLE_TRANSACTIONS, { logSummary: false });
+
+    state = ledgerReducer(state, {
+      type: "remove",
+      index: 1,
+    });
+
+    const expectedTransactions = SAMPLE_TRANSACTIONS.filter((_, idx) => idx !== 1);
+    const expectedHoldings = buildHoldings(expectedTransactions);
+
+    assert.deepEqual(state.holdings, expectedHoldings);
+  });
+
+  it("returns the initial state when reducer is seeded", () => {
+    const initialState = createInitialLedgerState();
+    assert.deepEqual(initialState.transactions, []);
+    assert.deepEqual(initialState.holdings, []);
+    assert.deepEqual(initialState.history, []);
+  });
+});
+

--- a/src/utils/holdingsLedger.js
+++ b/src/utils/holdingsLedger.js
@@ -1,0 +1,84 @@
+import {
+  applyTransactionSnapshot,
+  buildHoldingsState,
+  cloneHoldingsMap,
+  holdingsMapToArray,
+  revertTransactionSnapshot,
+} from "./holdings.js";
+
+function normalizeTransactions(transactions) {
+  if (!Array.isArray(transactions)) {
+    return [];
+  }
+  return transactions.map((transaction) => ({ ...transaction }));
+}
+
+export function buildLedgerFromTransactions(transactions, { logSummary = true } = {}) {
+  const normalized = normalizeTransactions(transactions);
+  const { holdingsMap, holdings, history } = buildHoldingsState(normalized, {
+    logSummary,
+  });
+
+  return {
+    transactions: normalized,
+    holdingsMap,
+    holdings,
+    history,
+  };
+}
+
+export function createInitialLedgerState() {
+  return buildLedgerFromTransactions([], { logSummary: false });
+}
+
+function appendTransaction(state, transaction) {
+  const nextTransactions = [...state.transactions, { ...transaction }];
+  const nextMap = cloneHoldingsMap(state.holdingsMap);
+  const snapshot = applyTransactionSnapshot(nextMap, transaction, []);
+  const nextHistory = [...state.history, snapshot];
+
+  return {
+    transactions: nextTransactions,
+    holdingsMap: nextMap,
+    holdings: holdingsMapToArray(nextMap),
+    history: nextHistory,
+  };
+}
+
+function removeTransaction(state, index) {
+  if (index < 0 || index >= state.transactions.length) {
+    return state;
+  }
+
+  const nextTransactions = state.transactions.filter((_, idx) => idx !== index);
+
+  if (index === state.transactions.length - 1) {
+    const nextMap = cloneHoldingsMap(state.holdingsMap);
+    const snapshot = state.history[state.history.length - 1];
+    revertTransactionSnapshot(nextMap, snapshot);
+    return {
+      transactions: nextTransactions,
+      holdingsMap: nextMap,
+      holdings: holdingsMapToArray(nextMap),
+      history: state.history.slice(0, -1),
+    };
+  }
+
+  return buildLedgerFromTransactions(nextTransactions, { logSummary: false });
+}
+
+export function ledgerReducer(state, action) {
+  switch (action.type) {
+    case "append":
+      return appendTransaction(state, action.transaction);
+    case "remove":
+      return removeTransaction(state, action.index);
+    case "replace":
+      return buildLedgerFromTransactions(action.transactions, {
+        logSummary: action.logSummary !== false,
+      });
+    default:
+      return state;
+  }
+}
+


### PR DESCRIPTION
## Summary
- add reusable holdings state helpers and ledger reducer for incremental updates
- switch the app to use the ledger reducer so holdings updates avoid full recomputation
- cover the new reducer with unit tests and mark PERF-2 as complete on the hardening scoreboard

## Testing
- npm run lint *(fails: pre-existing no-unused-vars violations in server/__tests__/compression.test.js, server/__tests__/integration.test.js, server/app.js)*
- npm test *(fails: pre-existing assertion in server/__tests__/storage_concurrency.test.js)*

------
https://chatgpt.com/codex/tasks/task_e_68e413f31a90832f99cb311c132ae5fe