### PR TITLE
feat: paginate transactions tab with virtualization

### DIFF
--- a/README.md
+++ b/README.md
@@ -359,7 +359,8 @@ Price data for interactive queries is fetched from [Stooq](https://stooq.com/). 
 
 4. **Usage:**
    - Navigate using the tab bar at the top of the workspace. The active tab is persisted while you save or load data.
-   - Add transactions via the **Transactions** tab. Enter **amount** and **price**; shares are computed automatically before submission.
+  - Add transactions via the **Transactions** tab. Enter **amount** and **price**; shares are computed automatically before submission.
+  - Scroll-free pagination keeps transaction tables responsive — 50 rows per page by default with controls to change the page size or step through history.
    - Review metrics, ROI performance and quick actions from the **Dashboard** tab.
    - Configure signals and monitor allocation details from the **Holdings** tab. Percentage windows determine when the last price falls below or above your buy/trim zones.
    - Audit deposits, withdrawals, and realised cash flow via the **History** tab’s contribution trends and timeline.

--- a/docs/HARDENING_SCOREBOARD.md
+++ b/docs/HARDENING_SCOREBOARD.md
@@ -1,4 +1,20 @@
 <!-- markdownlint-disable -->
+
+# Security Hardening Scoreboard
+
+Last Updated: 2025-10-07
+
+| ID    | Title                           | Status | Branch                         | PR | Evidence (CI/logs/coverage)                      | Notes |
+|-------|---------------------------------|--------|--------------------------------|----|--------------------------------------------------|-------|
+| DOC-1 | Enhanced user guide             | DONE   | main                           | —  | README.md Getting Started/API Key sections       | Content verified from audit checklist |
+| DOC-2 | Security documentation          | TODO   | —                              | —  | Missing `docs/SECURITY.md`                      | Needs incident response & key guidance |
+| SEC-10| API key strength enforcement    | DONE   | main                           | —  | server/middleware/validation.js; shared/apiKey.js | Zod schema + shared evaluator |
+| SEC-11| Security audit logging          | DONE   | main                           | —  | server/middleware/auditLog.js tests               | Structured logging in place |
+| DX-2  | Environment template            | DONE   | main                           | —  | `.env.example`; README environment table          | Template committed |
+| PERF-3| Transactions pagination rollout | DONE   | feat/perf-3-ui-virtualization | —  | `src/__tests__/Transactions.integration.test.jsx` | Client-side pagination + RTL coverage |
+
+---
+
 | ID      | Title                            | Severity | Owner | Status       | Branch            | PR | Evidence (CI) |
 |---------|----------------------------------|----------|-------|--------------|-------------------|----|---------------|
 | G1      | Coverage gate                    | HIGH     |       | DONE         | feat/ci-hardening | [Compare](https://github.com/cortega26/portfolio-manager-server/compare/main...feat/ci-hardening) | GitHub Actions: CI (nyc check-coverage) |
@@ -33,7 +49,7 @@
 | DX-2    | Environment template             | LOW      |       | DONE         | main              |    | `.env.example` committed; README "Environment configuration" section |
 | PERF-1  | Price caching + stale guard      | HIGH     |       | DONE         | feat\|fix/cache-etag-cache | Local: node --test cache_behaviors; Phase2 Item1 tests (`server/__tests__/api_cache.test.js`) |               |
 | PERF-2  | Incremental holdings             | MEDIUM   |       | DONE         | feat/perf-incremental-holdings | [Compare](https://github.com/cortega26/portfolio-manager-server/compare/main...feat/perf-incremental-holdings) | Local: npm test (storage concurrency failing pre-existing) |
-| PERF-3  | UI virtualization/pagination     | LOW      |       | TODO         |                   |    |               |
+| PERF-3  | UI virtualization/pagination     | LOW      |       | DONE         | feat/perf-3-ui-virtualization |    | Local: npm test -- --coverage (2025-10-07) |
 | PERF-4  | DB migration trigger             | LOW→MED  |       | TODO         |                   |    |               |
 | PERF-5  | Response compression             | MEDIUM   |       | DONE         | main              |    | `server/__tests__/compression.test.js` (Phase2 Item3) |
 | TEST-1  | Unit tests                       | HIGH     |       | DONE         | main              |    | Local: npm test (node --test coverage + src/__tests__/portfolioSchema.test.js) |


### PR DESCRIPTION
## Summary
- add client-side pagination and page controls to the Transactions tab so large ledgers stay responsive
- document the new pagination behavior in the README and extend integration coverage for paging/undo behavior
- sync docs/HARDENING_SCOREBOARD.md with the completed PERF-3 work and log the outstanding SECURITY.md deliverable

## Testing
- `npm run lint`
- `npm test -- --coverage`
- `npm run build`
- `npx gitleaks detect --no-banner`

📊 COMPLIANCE: 7/7 rules met (bandit/pip-audit not applicable for JS project)
🤖 Model: gpt-5-codex-medium
🧪 Tests: updated (Transactions pagination integration); coverage 91.54%
🔐 Security: gitleaks clean (bandit/pip-audit N/A)
⚠️ Failed: None

------
https://chatgpt.com/codex/tasks/task_e_68e492de5684832fa39c1e60a4f9a4e6