### PR TITLE
docs: refresh agents roadmap snapshot

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -100,6 +100,15 @@ Make sure this file is referenced in `vitest.config.ts` under `test.setupFiles`.
 - Vite build: `npm run build`.
 - Attach in the PR: CI link, coverage before→after, mutation score (if applicable), and a short list of fixed warnings.
 
+### 4.4 Roadmap snapshot (refreshed 2025-10-07)
+- **Phase 1 — Immediate**: Completed. README, API key enforcement, security audit logging, and `.env.example` all landed on
+  `main`; treat these as baselines when reviewing regressions.
+- **Phase 2 — Documentation**: `docs/openapi.yaml` now documents machine-readable errors (including `WEAK_KEY`), and this
+  `AGENTS.md` plus `docs/HARDENING_SCOREBOARD.md` were refreshed together. When instructions evolve, update all three (OpenAPI,
+  README, scoreboard) in the same PR to avoid drift.
+- **Phase 3 — Observability**: Upcoming work includes request-id propagation and admin tooling (see scoreboard entries `OBS-2`
+  and `OBS-3`). Start new work by confirming status in `docs/HARDENING_SCOREBOARD.md`.
+
 ---
 
 ## 5) Default Acceptance Criteria (for any agent PR)

--- a/docs/HARDENING_SCOREBOARD.md
+++ b/docs/HARDENING_SCOREBOARD.md
@@ -24,7 +24,7 @@ Last Updated: 2025-10-07 (revalidated for AI_IMPLEMENTATION_PROMPT.md)
 | P2-DOC-1  | README deep-dive sections              | DONE                                   | main   | —  | README.md (Usage Examples, Monitoring, CI, Known Limitations) | Adds usage walkthroughs, troubleshooting, and operational guidance. |
 | P2-DOC-2  | HARDENING_SCOREBOARD sync process      | DONE                                   | main   | —  | docs/HARDENING_SCOREBOARD.md (this file) | Status verified against AI_IMPLEMENTATION_PROMPT.md. |
 | P2-DOC-3  | OpenAPI error codes (WEAK_KEY, etc.)   | DONE                                   | main   | —  | docs/openapi.yaml (WEAK_KEY examples, ErrorResponse schema) | 400/401/403/429 now document error payloads and security requirements. |
-| P2-DOC-4  | AGENTS.md roadmap refresh              | TODO                                   | —      | —  | —                           | Review required to incorporate latest timelines once OpenAPI docs are updated. |
+| P2-DOC-4  | AGENTS.md roadmap refresh              | IN PROGRESS                           | docs/p2-doc-4-agents-roadmap | —      | AGENTS.md §4.4 roadmap snapshot | Refreshed alongside docs/openapi.yaml; keep README + scoreboard in sync within the same PR. |
 
 ## Phase 3 — Observability & Future Work
 


### PR DESCRIPTION
## Summary
- add a roadmap snapshot section to `AGENTS.md` so instructions track the refreshed OpenAPI guidance and scoreboard
- update `docs/HARDENING_SCOREBOARD.md` to show task P2-DOC-4 as in progress on branch `docs/p2-doc-4-agents-roadmap`

## Testing
- `ruff check .`
- `black --check .`
- `isort --check-only .`
- `mypy .`
- `pytest -q`
- `npm run lint --if-present`
- `npm run typecheck --if-present`
- `npm test -- --coverage`
- `NODE_OPTIONS="--trace-warnings --trace-deprecation --throw-deprecation" npm test -- --coverage`
- `npm run build`

## Compliance
📊 COMPLIANCE: 6/7 rules met (missing: R2 tooling deferred to CI)
🤖 Model: gpt-5-codex-medium
🧪 Tests: none created/updated; coverage 92.02% (npm test -- --coverage, strict run)
🔐 Security: bandit/gitleaks/pip-audit unavailable locally (Deferred to CI)
⚠️ Failed: R2


------
https://chatgpt.com/codex/tasks/task_e_68e507f2eca4832fbb229d5ce904f9cc