### PR TITLE
docs: add comprehensive testing strategy guide

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,6 +40,7 @@ Persistence sanity‑check: after adding a portfolio you should observe files li
 ---
 
 ## 2) Quality Policy (tests, coverage, strictness)
+- **Reference:** Follow the detailed [testing strategy guide](docs/testing-strategy.md) for expectations across unit, integration, property, and mutation layers.
 - **Test runner:** Vitest (preferred). If Jest is present, keep parity; do not introduce heavy toolchains.
 - **Coverage:** enable `--coverage` and enforce thresholds (global ≥ **80%**, **changed files ≥ 90%**). Never lower thresholds.
 - **Order randomization:** run with shuffle to reveal order dependencies.

--- a/README.md
+++ b/README.md
@@ -316,7 +316,7 @@ This codebase has been updated with critical fixes from a comprehensive audit:
 For a full breakdown see [docs/testing-strategy.md](docs/testing-strategy.md).
 The suite enforces randomized execution order, coverage thresholds, and warnings-as-errors for project code:
 
-- `npm test` – runs all unit, integration, and property-based tests once with deterministic shuffling, `c8` coverage enforcement (branches ≥ 70%, functions ≥ 90%, lines/statements ≥ 90%), and warning promotion via `server/__tests__/setup/global.js`.
+- `npm test` – runs all unit, integration, and property-based tests once with deterministic shuffling, `c8` coverage enforcement (global coverage ≥ 80%, touched files ≥ 90%, branch coverage ≥ 70%), and warning promotion via `server/__tests__/setup/global.js`.
 - `npm run test:ci` – identical to `npm test` but pins `TEST_SHUFFLE_SEED=20251006` for reproducible CI logs.
 - `npm run test:stress` – executes the full suite five times (without coverage) to expose order-dependent or flaky behaviour.
 - `npm run test:mutation` – executes [StrykerJS](https://stryker-mutator.io) against portfolio math modules via the deterministic shuffle runner (coverage disabled) and reports the mutation score. Use for nightly/weekly assurance.
@@ -327,7 +327,7 @@ The suite enforces randomized execution order, coverage thresholds, and warnings
 | `FC_SEED`          | int       | Derived from `TEST_SHUFFLE_SEED` | No      | Controls the Fast-Check property test seeds; helps reproduce counterexamples. |
 | `FC_RUNS`          | int       | `80`                            | No       | Adjusts the number of Fast-Check executions per property test (increase for additional assurance). |
 
-> Mutation testing: the ROI property harness scores ≥70% mutation coverage on `src/utils/roi.js`. Run `npm run test:mutation` before shipping pricing/benchmark changes to confirm the ROI guardrails still hold.
+> Mutation testing: the ROI property harness scores ≥70% mutation coverage on `src/utils/roi.js`. Run `npm run test:mutation` before shipping pricing/benchmark changes to confirm the ROI guardrails still hold. Review the [testing strategy guide](docs/testing-strategy.md#mutation-testing) for expectations and reporting tips.
 
 The coverage-aware runner still loads [`docs/openapi.yaml`](docs/openapi.yaml) via `server/__tests__/api_contract.test.js`, exercises the React zod validator in `src/__tests__/portfolioSchema.test.js`, and drives a full portfolio lifecycle in `server/__tests__/integration.test.js`. API failure paths, edge cases, and math policies remain covered; the new property tests harden ROI, benchmark, and cash accrual logic against seeded bugs.
 

--- a/docs/HARDENING_SCOREBOARD.md
+++ b/docs/HARDENING_SCOREBOARD.md
@@ -2,7 +2,7 @@
 
 # Security Hardening Scoreboard
 
-Last Updated: 2025-10-08 (Phase 3 sync: API version routing + request IDs)
+Last Updated: 2025-10-08 (Phase 3 sync: API version routing + request IDs; testing strategy guide finalized)
 
 Verification 2025-10-07: Reviewed `AI_IMPLEMENTATION_PROMPT.md` items and confirmed
 P1-DOC-1 through P1-DX-1 remain satisfied (README onboarding, API key validation,

--- a/docs/testing-strategy.md
+++ b/docs/testing-strategy.md
@@ -1,0 +1,82 @@
+# Testing Strategy Guide
+
+This guide documents how the portfolio manager project validates quality across unit, integration, property, and mutation testing. All contributors must follow these practices for every change that lands on `main`.
+
+## Goals and Quality Gates
+
+- **Global coverage:** ≥ 80% statements/lines across the repository on every test run.
+- **Touched files coverage:** ≥ 90% statements/lines for any file modified in a pull request.
+- **Branch coverage:** ≥ 70% for critical control paths (enforced via Vitest configuration).
+- **Zero tolerance for noisy logs:** Any `console.warn`/`console.error` emitted during tests fails the run. Fix the underlying issue instead of muting output.
+- **Deterministic reproducibility:** Runs must be reproducible via `TEST_SHUFFLE_SEED` and Fast-Check seeds captured in CI logs.
+
+Coverage thresholds are enforced through `c8`/Vitest reporters in CI. Pull requests that lower coverage or introduce warnings must not merge.
+
+## Test Layers
+
+### Unit Tests
+
+Unit suites cover pure utilities, React hooks, and Express middleware in isolation.
+
+- Prefer lightweight factories over fixtures; keep execution deterministic.
+- Mock network and filesystem boundaries with `vi.mock` to avoid non-deterministic behavior.
+- Keep functions short (≤ 80 LOC) and assert both success and failure paths.
+
+### Integration Tests
+
+Integration suites exercise complete workflows:
+
+- `server/__tests__/integration.test.js` drives REST endpoints end-to-end against the Express app with in-memory persistence.
+- Frontend integration tests under `src/__tests__` mount components with React Testing Library to validate user flows.
+- Contract tests ensure OpenAPI parity by loading [`docs/openapi.yaml`](openapi.yaml) directly.
+
+### Property-Based Tests
+
+Property testing uses [`fast-check`](https://github.com/dubzzz/fast-check) to validate invariants across broad input spaces.
+
+- ROI, benchmark tracking, and cash accrual modules provide property harnesses under `server/__tests__` and `src/__tests__`.
+- Seeds derive from `TEST_SHUFFLE_SEED` to keep counterexamples reproducible. Override via `FC_SEED` and increase executions with `FC_RUNS` when hardening.
+- Minimize shrink noise by constraining arbitraries to domain-valid data (e.g., bounded trade amounts, sorted timestamps when required).
+
+## Mutation Testing
+
+Mutation testing is powered by [StrykerJS](https://stryker-mutator.io) (`stryker.conf.json`).
+
+- Targeted at ROI math, benchmark parity, and cash accrual modules.
+- Excludes slow UI suites to keep runtime manageable.
+- Use before shipping substantial finance or validation changes to ensure properties and unit tests kill mutants.
+- Mutation score must remain ≥ 70% for the targeted packages; investigate surviving mutants immediately.
+
+Run mutations locally with:
+
+```bash
+npm run test:mutation
+```
+
+Review `reports/mutation/mutation.html` for surviving mutants and update assertions accordingly.
+
+## Stress and Order Sensitivity Testing
+
+`npm run test:stress` executes the full Vitest suite five consecutive times without coverage. This surfaces hidden order dependencies and race conditions. Ensure the command finishes cleanly before merging large refactors or flaky-test fixes.
+
+## Console Warning Policy
+
+Tests fail fast on console warnings/errors via `setupTests` hooks (`server/__tests__/setup/global.js` and `src/setupTests.ts`). When third-party packages emit unavoidable warnings, isolate them with targeted spies and document the rationale inline. Never mute project warnings globally.
+
+## Commands Reference
+
+Use the following commands during local development and CI:
+
+| Command | Purpose |
+| --- | --- |
+| `npm test` | Runs the Vitest suite once with coverage enforcement, warning promotion, and deterministic shuffling. |
+| `npm run test:stress` | Executes the suite five times without coverage to detect flakiness. |
+| `npm run test:mutation` | Invokes StrykerJS against targeted math modules and reports the mutation score. |
+
+For strict deprecation/warning checks, run:
+
+```bash
+NODE_OPTIONS="--trace-warnings --trace-deprecation --throw-deprecation" npm test -- --coverage
+```
+
+Document seeds and command outputs in PR descriptions to aid reproducibility.


### PR DESCRIPTION
## Summary
- add a dedicated testing strategy guide that documents coverage thresholds, property testing, mutation testing, and strict console warning policies
- reference the guide from AGENTS.md and README.md so contributors have a single source for test expectations
- update the hardening scoreboard metadata to reflect the synced documentation state

## Testing
- Deferred to CI (documentation-only change)

📊 COMPLIANCE: 7/7 rules met (None missing)
🤖 Model: gpt-5-codex-low
🧪 Tests: none (docs-only; coverage unaffected) – Deferred to CI
🔐 Security: bandit/gitleaks/pip-audit deferred to CI
⚠️ Failed: None

------
https://chatgpt.com/codex/tasks/task_e_68e56774f72c832fbb1dfda63ea91fbd