### PR TITLE
feat: refresh dashboard KPI panel with cash metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -378,7 +378,7 @@ These changes improve data integrity and mathematical correctness.
 
 The interface organises the experience across focused tabs:
 
-- **Dashboard** – portfolio KPIs, ROI comparisons with benchmark toggles (SPY, blended, ex-cash, cash), and quick actions to refresh analytics or open reference material.
+- **Dashboard** – portfolio KPIs, cash allocation, ROI comparisons with benchmark toggles (SPY, blended, ex-cash, cash), and quick actions to refresh analytics or open reference material.
 - **Holdings** – consolidated holdings table plus configurable buy/trim signal bands for each ticker.
 - **Transactions** – dedicated form for capturing trades and a chronological activity table.
 - **History** – contribution trends and a chronological timeline of activity, grouped by calendar month.
@@ -423,6 +423,19 @@ Price data for interactive queries is fetched from [Stooq](https://stooq.com/). 
 
 The Dashboard ROI chart now consumes `/api/returns/daily` and `/api/benchmarks/summary` to layer 100% SPY, blended, risk-sleeve (ex-cash), and cash yield series alongside the portfolio. Users can toggle any combination of benchmarks, and the selection is saved to browser storage so the chart opens with the same comparison after refresh or sign-in. Each toggle is keyboard accessible, labelled for assistive tech, and mirrors the colors used in the legend for clarity.
 
+#### KPI panel for cash & benchmarks
+
+The dashboard KPI panel blends ledger balances with the benchmark snapshot documented in [`docs/cash-benchmarks.md`](docs/cash-benchmarks.md):
+
+- **Net Asset Value** – total risk assets plus cash, with the description surfacing the current cash balance tracked by the ledger.
+- **Total Return** – realised + unrealised P&L alongside the cumulative ROI in percentage points.
+- **Invested Capital** – capital deployed into positions with a quick count of tracked holdings and their combined risk-asset value.
+- **Cash Allocation** – start-of-day cash weight (cash ÷ NAV) rounded to one decimal place per the benchmark spec.
+- **Cash Drag** – difference between the 100% SPY track and the blended benchmark, highlighting the opportunity cost of idle cash.
+- **Benchmark Delta** – side-by-side ROI deltas versus SPY and the blended sleeve so deviations stand out without opening the full chart.
+
+Each card keeps the prior responsive layout (two columns on small screens, three on large, expanding to six cards on wide displays) and inherits dark-mode styling so the refreshed metrics remain legible in both themes.
+
 3. **Start the frontend:**
 
    ```bash
@@ -435,7 +448,7 @@ The Dashboard ROI chart now consumes `/api/returns/daily` and `/api/benchmarks/s
    - Navigate using the tab bar at the top of the workspace. The active tab is persisted while you save or load data.
   - Add transactions via the **Transactions** tab. Enter **amount** and **price**; shares are computed automatically before submission.
   - Scroll-free pagination keeps transaction tables responsive — 50 rows per page by default with controls to change the page size or step through history.
-   - Review metrics, ROI performance and quick actions from the **Dashboard** tab.
+   - Review metrics, ROI performance, cash allocation, and benchmark deltas from the **Dashboard** tab.
    - Configure signals and monitor allocation details from the **Holdings** tab. Percentage windows determine when the last price falls below or above your buy/trim zones.
    - Audit deposits, withdrawals, and realised cash flow via the **History** tab’s contribution trends and timeline.
    - Inspect diversification, return ratios, and ROI highlights through the **Metrics** tab.

--- a/docs/HARDENING_SCOREBOARD.md
+++ b/docs/HARDENING_SCOREBOARD.md
@@ -61,7 +61,7 @@ template) with no regressions detected.
 | ID        | Title                                      | Status (TODO/IN PROGRESS/DONE/BLOCKED) | Branch | PR | Evidence (CI/logs/coverage) | Notes |
 |-----------|--------------------------------------------|----------------------------------------|--------|----|-----------------------------|-------|
 | P4-UI-1   | Benchmark view toggles & blended charting  | DONE                                   | feat/phase4-benchmark-toggles | —  | README.md §Benchmark toggles & ROI comparisons; Tests: `npm test -- --coverage` | Dashboard ROI chart exposes persisted benchmark toggles (SPY, blended, ex-cash, cash) powered by `/api/returns/daily`. |
-| P4-UI-2   | KPI panel refresh for cash & benchmarks     | TODO                                   | —      | —  | —                           | Update dashboard KPIs to surface cash drag metrics alongside SPY benchmarks before Phase 4 sign-off. |
+| P4-UI-2   | KPI panel refresh for cash & benchmarks     | DONE                                   | feat/phase4-kpi-refresh | —  | README.md §KPI panel for cash & benchmarks; Tests: `npm run test -- --coverage` | Dashboard KPIs include cash allocation, drag, and benchmark deltas aligned with docs/cash-benchmarks.md. |
 | P4-DOC-1  | Frontend operations playbook                | TODO                                   | —      | —  | —                           | Document Admin tab workflows and benchmark toggles across README + docs once UI changes land. |
 
 > Historical scoreboard snapshots remain available in git history prior to this commit.

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -358,6 +358,7 @@ export default function App() {
               <DashboardTab
                 metrics={metrics}
                 roiData={roiData}
+                transactions={transactions}
                 loadingRoi={loadingRoi}
                 onRefreshRoi={handleRefreshRoi}
               />

--- a/src/__tests__/App.test.jsx
+++ b/src/__tests__/App.test.jsx
@@ -85,7 +85,7 @@ afterEach(() => {
 describe("App tab navigation", () => {
   it("renders dashboard by default and shows validation when saving without an ID", async () => {
     render(<App />);
-    assert.ok(await screen.findByText("Portfolio Value"));
+    assert.ok(await screen.findByText("Net Asset Value"));
 
     const saveButton = screen.getByRole("button", { name: /save portfolio/i });
     await userEvent.click(saveButton);

--- a/src/__tests__/DashboardTab.metrics.test.jsx
+++ b/src/__tests__/DashboardTab.metrics.test.jsx
@@ -1,0 +1,102 @@
+import { afterEach, beforeEach, describe, it } from "node:test";
+import { strict as assert } from "node:assert";
+import { JSDOM } from "jsdom";
+import React from "react";
+import { cleanup, render, screen } from "@testing-library/react";
+
+import DashboardTab from "../components/DashboardTab.jsx";
+import {
+  computeCashBalance,
+  deriveDashboardMetrics,
+} from "../hooks/usePortfolioMetrics.js";
+
+const TRANSACTION_FIXTURE = [
+  { date: "2024-01-01", type: "DEPOSIT", amount: 1000 },
+  { date: "2024-01-02", type: "BUY", amount: -400 },
+  { date: "2024-01-05", type: "SELL", amount: 200 },
+  { date: "2024-01-07", type: "WITHDRAWAL", amount: 50 },
+  { date: "2024-01-09", type: "FEE", amount: 5 },
+];
+
+const METRICS_FIXTURE = {
+  totalValue: 600,
+  totalCost: 500,
+  totalRealised: 50,
+  totalUnrealised: 100,
+  holdingsCount: 3,
+};
+
+const ROI_FIXTURE = [
+  { date: "2024-01-01", portfolio: 0, spy: 0, blended: 0, exCash: 0, cash: 0 },
+  { date: "2024-01-10", portfolio: 5.5, spy: 6, blended: 4.5, exCash: 7.2, cash: 0.9 },
+];
+
+describe("DashboardTab metrics derivation", () => {
+  let dom;
+
+  beforeEach(() => {
+    dom = new JSDOM("<!doctype html><html><body></body></html>", {
+      url: "http://localhost/",
+    });
+    global.window = dom.window;
+    global.document = dom.window.document;
+    global.navigator = dom.window.navigator;
+    global.HTMLElement = dom.window.HTMLElement;
+    global.SVGElement = dom.window.SVGElement;
+    global.Node = dom.window.Node;
+    global.localStorage = dom.window.localStorage;
+  });
+
+  afterEach(() => {
+    cleanup();
+    dom.window.close();
+    delete global.window;
+    delete global.document;
+    delete global.navigator;
+    delete global.HTMLElement;
+    delete global.SVGElement;
+    delete global.Node;
+    delete global.localStorage;
+  });
+
+  it("computes cash balance from mixed transactions", () => {
+    const balance = computeCashBalance(TRANSACTION_FIXTURE);
+    assert.equal(balance, 745);
+  });
+
+  it("derives cash allocation and benchmark deltas", () => {
+    const derived = deriveDashboardMetrics({
+      metrics: METRICS_FIXTURE,
+      transactions: TRANSACTION_FIXTURE,
+      roiData: ROI_FIXTURE,
+    });
+
+    assert.equal(Math.round(derived.totals.totalNav), 1345);
+    assert.equal(Math.round(derived.percentages.returnPct), 30);
+    assert.ok(Math.abs(derived.percentages.cashAllocationPct - 55.35) < 0.1);
+    assert.equal(derived.percentages.cashDragPct, 1.5);
+    assert.equal(derived.percentages.spyDeltaPct, -0.5);
+    assert.equal(derived.percentages.blendedDeltaPct, 1.0);
+  });
+
+  it("renders dashboard cards with derived KPI values", () => {
+    render(
+      <DashboardTab
+        metrics={METRICS_FIXTURE}
+        roiData={ROI_FIXTURE}
+        transactions={TRANSACTION_FIXTURE}
+        loadingRoi={false}
+        onRefreshRoi={() => {}}
+      />,
+    );
+
+    assert.ok(screen.getByText("Net Asset Value"));
+    assert.ok(screen.getByText("Cash balance $745.00"));
+    assert.ok(screen.getByText("Cash Allocation"));
+    assert.ok(screen.getByText("55.4%"));
+    assert.ok(screen.getByText(/Cash Drag/));
+    assert.ok(screen.getByText(/\+1.50%/));
+    assert.ok(screen.getByText(/Benchmark Delta/));
+    assert.ok(screen.getByText(/Blended \+1.00%/));
+  });
+});

--- a/src/__tests__/format.test.js
+++ b/src/__tests__/format.test.js
@@ -1,6 +1,6 @@
 import { describe, it } from "node:test";
 import { strict as assert } from "node:assert";
-import { formatCurrency, formatPercent } from "../utils/format.js";
+import { formatCurrency, formatPercent, formatSignedPercent } from "../utils/format.js";
 
 describe("format utilities", () => {
   it("formats currency with fallback for invalid inputs", () => {
@@ -13,5 +13,12 @@ describe("format utilities", () => {
     assert.equal(formatPercent(12.3456), "12.35%");
     assert.equal(formatPercent(9.1, 1), "9.1%");
     assert.equal(formatPercent(undefined), "—");
+  });
+
+  it("formats signed percentage deltas", () => {
+    assert.equal(formatSignedPercent(1.234, 2), "+1.23%");
+    assert.equal(formatSignedPercent(-0.987, 2), "-0.99%");
+    assert.equal(formatSignedPercent(0, 2), "0.00%");
+    assert.equal(formatSignedPercent(Number.NaN, 2), "—");
   });
 });

--- a/src/hooks/usePortfolioMetrics.js
+++ b/src/hooks/usePortfolioMetrics.js
@@ -1,0 +1,105 @@
+import { useMemo } from "react";
+
+const CASH_IN_TYPES = new Set(["DEPOSIT", "DIVIDEND", "INTEREST"]);
+const CASH_OUT_TYPES = new Set(["WITHDRAWAL", "FEE"]);
+
+function normalizeType(value) {
+  return typeof value === "string" ? value.trim().toUpperCase() : "";
+}
+
+function safeNumber(value) {
+  const numeric = Number(value);
+  return Number.isFinite(numeric) ? numeric : 0;
+}
+
+export function computeCashBalance(transactions = []) {
+  return transactions.reduce((balance, transaction) => {
+    if (!transaction) {
+      return balance;
+    }
+    const type = normalizeType(transaction.type);
+    const amount = Number.parseFloat(transaction.amount ?? 0);
+    if (!Number.isFinite(amount)) {
+      return balance;
+    }
+
+    if (type === "BUY") {
+      return balance - Math.abs(amount);
+    }
+    if (type === "SELL") {
+      return balance + Math.abs(amount);
+    }
+    if (CASH_IN_TYPES.has(type)) {
+      return balance + amount;
+    }
+    if (CASH_OUT_TYPES.has(type)) {
+      return balance - Math.abs(amount);
+    }
+    return balance;
+  }, 0);
+}
+
+export function resolveLatestRoiSnapshot(roiData = []) {
+  for (let index = roiData.length - 1; index >= 0; index -= 1) {
+    const entry = roiData[index];
+    if (!entry) {
+      continue;
+    }
+    const portfolio = safeNumber(entry.portfolio);
+    const spy = safeNumber(entry.spy);
+    const blended = safeNumber(entry.blended);
+    const exCash = safeNumber(entry.exCash);
+    const cash = safeNumber(entry.cash);
+    if (portfolio || spy || blended || exCash || cash) {
+      return { portfolio, spy, blended, exCash, cash };
+    }
+  }
+  return { portfolio: 0, spy: 0, blended: 0, exCash: 0, cash: 0 };
+}
+
+export function deriveDashboardMetrics({ metrics, transactions, roiData } = {}) {
+  const totalValue = safeNumber(metrics?.totalValue);
+  const totalCost = safeNumber(metrics?.totalCost);
+  const totalRealised = safeNumber(metrics?.totalRealised);
+  const totalUnrealised = safeNumber(metrics?.totalUnrealised);
+  const holdingsCount = Math.max(0, Math.trunc(safeNumber(metrics?.holdingsCount)));
+
+  const cashBalance = computeCashBalance(transactions);
+  const totalReturn = totalRealised + totalUnrealised;
+  const returnPct = totalCost === 0 ? 0 : (totalReturn / totalCost) * 100;
+  const totalNav = totalValue + cashBalance;
+
+  const latest = resolveLatestRoiSnapshot(roiData);
+  const cashAllocationPct = totalNav === 0 ? 0 : (cashBalance / totalNav) * 100;
+  const cashDragPct = latest.spy - latest.blended;
+  const spyDeltaPct = latest.portfolio - latest.spy;
+  const blendedDeltaPct = latest.portfolio - latest.blended;
+
+  return {
+    totals: {
+      totalValue,
+      totalCost,
+      totalRealised,
+      totalUnrealised,
+      totalReturn,
+      totalNav,
+      cashBalance,
+      holdingsCount,
+    },
+    percentages: {
+      returnPct,
+      cashAllocationPct,
+      cashDragPct,
+      spyDeltaPct,
+      blendedDeltaPct,
+    },
+    latest,
+  };
+}
+
+export function usePortfolioMetrics({ metrics, transactions, roiData } = {}) {
+  return useMemo(
+    () => deriveDashboardMetrics({ metrics, transactions, roiData }),
+    [metrics, transactions, roiData],
+  );
+}

--- a/src/utils/format.js
+++ b/src/utils/format.js
@@ -10,10 +10,40 @@ export function formatCurrency(value) {
   }).format(value);
 }
 
+function isNilOrNaN(value) {
+  return Number.isNaN(value) || value === undefined || value === null;
+}
+
 export function formatPercent(value, fractionDigits = 2) {
-  if (Number.isNaN(value) || value === undefined || value === null) {
+  if (isNilOrNaN(value)) {
     return "—";
   }
 
-  return `${value.toFixed(fractionDigits)}%`;
+  const normalized = Number(value);
+  if (!Number.isFinite(normalized)) {
+    return "—";
+  }
+
+  return `${normalized.toFixed(fractionDigits)}%`;
+}
+
+export function formatSignedPercent(value, fractionDigits = 2) {
+  if (isNilOrNaN(value)) {
+    return "—";
+  }
+
+  const normalized = Number(value);
+  if (!Number.isFinite(normalized)) {
+    return "—";
+  }
+
+  const rounded = Number(normalized.toFixed(fractionDigits));
+  const isNegativeZero = Object.is(rounded, -0);
+  if (rounded === 0 || isNegativeZero) {
+    return `${(0).toFixed(Math.max(0, fractionDigits))}%`;
+  }
+
+  const absolute = Math.abs(rounded).toFixed(fractionDigits);
+  const sign = rounded > 0 ? "+" : "-";
+  return `${sign}${absolute}%`;
 }


### PR DESCRIPTION
## Summary
- add a reusable `usePortfolioMetrics` hook to derive cash balances, allocation, and benchmark deltas for the dashboard
- update the dashboard KPI cards to present cash balance context, cash drag, and benchmark comparisons with responsive layout tweaks
- document the refreshed KPIs and mark P4-UI-2 complete in the hardening scoreboard alongside supporting tests for metric math and formatting

## Testing
- npm run lint
- npm run test

## Compliance
📊 COMPLIANCE: 6/7 rules met (R2 pending – bandit/gitleaks/pip-audit unavailable locally; deferred to CI)
🤖 Model: gpt-5-codex-medium
🧪 Tests: created (DashboardTab.metrics, format sign percent) / updated; coverage via suite (see README references)
🔐 Security: bandit/gitleaks/pip-audit → Deferred to CI (tools missing)
⚠️ Failed: R2


------
https://chatgpt.com/codex/tasks/task_e_68e5a6178ddc832f85a116253b974588