### PR TITLE
feat: add benchmark reset control to dashboard toggles

### DIFF
--- a/README.md
+++ b/README.md
@@ -423,7 +423,7 @@ Price data for interactive queries is fetched from [Stooq](https://stooq.com/). 
 
 #### Benchmark toggles & ROI comparisons
 
-The Dashboard ROI chart now consumes `/api/returns/daily` and `/api/benchmarks/summary` to layer 100% SPY, blended, risk-sleeve (ex-cash), and cash yield series alongside the portfolio. Users can toggle any combination of benchmarks, and the selection is saved to browser storage so the chart opens with the same comparison after refresh or sign-in. Each toggle is keyboard accessible, labelled for assistive tech, and mirrors the colors used in the legend for clarity.
+The Dashboard ROI chart now consumes `/api/returns/daily` and `/api/benchmarks/summary` to layer 100% SPY, blended, risk-sleeve (ex-cash), and cash yield series alongside the portfolio. Users can toggle any combination of benchmarks, reset to the recommended comparison with a dedicated control, and the selection is saved to browser storage so the chart opens with the same comparison after refresh or sign-in. Each toggle is keyboard accessible, labelled for assistive tech, and mirrors the colors used in the legend for clarity. The reset button is disabled while the default blend is active so keyboard/screen-reader users receive clear affordances about state.
 
 #### KPI panel for cash & benchmarks
 

--- a/docs/HARDENING_SCOREBOARD.md
+++ b/docs/HARDENING_SCOREBOARD.md
@@ -2,7 +2,7 @@
 
 # Security Hardening Scoreboard
 
-Last Updated: 2025-10-09 (Phase 3 observability deliverables verified; Phase 4 frontend backlog staged)
+Last Updated: 2025-10-10 (Phase 4 dashboard refinements verified; benchmark reset control shipped)
 
 Verification 2025-10-09: Re-reviewed `AI_IMPLEMENTATION_PROMPT.md` alongside the
 merged codebase to confirm Phase 3 items (CODE-1, PERF-4, PERF-5, API-1,
@@ -60,9 +60,9 @@ template) with no regressions detected.
 
 | ID        | Title                                      | Status (TODO/IN PROGRESS/DONE/BLOCKED) | Branch | PR | Evidence (CI/logs/coverage) | Notes |
 |-----------|--------------------------------------------|----------------------------------------|--------|----|-----------------------------|-------|
-| P4-UI-1   | Benchmark view toggles & blended charting  | DONE                                   | feat/phase4-benchmark-toggles | —  | README.md §Benchmark toggles & ROI comparisons; Tests: `npm test -- --coverage` | Dashboard ROI chart exposes persisted benchmark toggles (SPY, blended, ex-cash, cash) powered by `/api/returns/daily`. |
+| P4-UI-1   | Benchmark view toggles & blended charting  | DONE                                   | feat/phase4-benchmark-reset | —  | README.md §Benchmark toggles & ROI comparisons; Tests: `NO_NETWORK_TESTS=1 npm run test:fast` | ROI chart exposes persisted benchmark toggles (SPY, blended, ex-cash, cash) plus a reset control that reverts to the default blend with keyboard cues. |
 | P4-UI-2   | KPI panel refresh for cash & benchmarks     | DONE                                   | feat/phase4-kpi-refresh | —  | README.md §KPI panel for cash & benchmarks; Tests: `npm run test -- --coverage` | Dashboard KPIs include cash allocation, drag, and benchmark deltas aligned with docs/cash-benchmarks.md. |
-| P4-DOC-1  | Frontend operations playbook                | DONE                                   | feat/phase4-frontend-playbook | —  | docs/frontend-operations.md; README.md §Frontend operations workflow | Playbook covers Admin tab workflows, benchmark toggles, KPI validation, and incident response; README linked for ops handoffs. |
+| P4-DOC-1  | Frontend operations playbook                | DONE                                   | feat/phase4-frontend-playbook | —  | docs/frontend-operations.md; README.md §Frontend operations workflow | Playbook covers Admin tab workflows, benchmark toggles (including reset flow), KPI validation, and incident response; README linked for ops handoffs. |
 
 > Historical scoreboard snapshots remain available in git history prior to this commit.
 

--- a/docs/frontend-operations.md
+++ b/docs/frontend-operations.md
@@ -42,6 +42,7 @@ This playbook standardizes how to operate, verify, and troubleshoot the Vite/Rea
    - Expect ROI chart to render with default benchmark (SPY) and toggles visible.
 2. Toggle to **Blended Benchmark** and **Ex-Cash** modes.
    - Confirm legend updates and series visibility changes without console errors (check browser devtools).
+   - Use the **Reset** button to restore SPY + Blended default and verify the control disables itself once the default blend is active.
    - Refresh the page to ensure the selection persists (localStorage backed preference).
 3. Validate KPI cards.
    - Ensure Cash Allocation %, Cash Drag Impact, SPY Delta, and Blended Benchmark Delta display values consistent with staging snapshots.
@@ -73,6 +74,7 @@ Record results in the release ticket. Flag any discrepancies for immediate triag
    - Observe chart updates (line color + legend entry).
    - Check Admin tab → Feature Flags section to verify `VITE_FEATURE_BENCHMARK_TOGGLES` is `true`.
 4. Use browser network tab to confirm `/api/returns/daily` responses contain benchmark arrays; if missing, escalate to backend on-call.
+5. Activate at least one non-default toggle, reload the page, then use **Reset** to confirm the default SPY + Blended pairing returns without a second reload.
 
 ## KPI Refresh Validation
 

--- a/src/__tests__/DashboardTab.test.jsx
+++ b/src/__tests__/DashboardTab.test.jsx
@@ -6,6 +6,7 @@ import userEvent from "@testing-library/user-event";
 import React from "react";
 
 import DashboardTab from "../components/DashboardTab.jsx";
+import { getBenchmarkStorageKey } from "../hooks/usePersistentBenchmarkSelection.js";
 
 const METRICS_FIXTURE = {
   totalValue: 1000,
@@ -71,19 +72,31 @@ describe("DashboardTab benchmark controls", () => {
       />,
     );
 
+    const storageKey = getBenchmarkStorageKey();
+
     const spyToggle = screen.getByRole("button", {
       name: /100% spy benchmark/i,
     });
     const blendedToggle = screen.getByRole("button", {
       name: /blended benchmark/i,
     });
+    const resetButton = screen.getByRole("button", { name: /reset/i });
 
     assert.equal(spyToggle.getAttribute("aria-pressed"), "true");
     assert.equal(blendedToggle.getAttribute("aria-pressed"), "true");
+    assert.equal(resetButton.hasAttribute("disabled"), true);
 
     await user.click(spyToggle);
     assert.equal(spyToggle.getAttribute("aria-pressed"), "false");
     assert.equal(blendedToggle.getAttribute("aria-pressed"), "true");
+    assert.equal(resetButton.hasAttribute("disabled"), false);
+    assert.deepEqual(JSON.parse(window.localStorage.getItem(storageKey)), ["blended"]);
+
+    await user.click(resetButton);
+    assert.equal(spyToggle.getAttribute("aria-pressed"), "true");
+    assert.equal(blendedToggle.getAttribute("aria-pressed"), "true");
+    assert.equal(resetButton.hasAttribute("disabled"), true);
+    assert.deepEqual(JSON.parse(window.localStorage.getItem(storageKey)), ["spy", "blended"]);
 
     cleanup();
 
@@ -100,5 +113,7 @@ describe("DashboardTab benchmark controls", () => {
       name: /100% spy benchmark/i,
     });
     assert.equal(spyTogglePersisted.getAttribute("aria-pressed"), "false");
+    const resetButtonPersisted = screen.getByRole("button", { name: /reset/i });
+    assert.equal(resetButtonPersisted.hasAttribute("disabled"), false);
   });
 });


### PR DESCRIPTION
## Summary
- add an accessible reset control to the dashboard benchmark toggles and persist the default blend state
- extend DashboardTab tests to cover reset persistence and disabled affordances
- document the reset workflow across README, HARDENING_SCOREBOARD, and the frontend operations playbook

## Testing
- `npm run lint`
- `NO_NETWORK_TESTS=1 npm run test:fast`
- `npm run build`

📊 COMPLIANCE: 7/7 rules met (None)
🤖 Model: gpt-5-codex-medium
🧪 Tests: updated (NO_NETWORK_TESTS=1 npm run test:fast)
🔐 Security: bandit/gitleaks/pip-audit deferred to CI (FAST lane)
⚠️ Failed: None

------
https://chatgpt.com/codex/tasks/task_e_68e5afcbf37c832fae489474760fb5e3