### PR TITLE
feat: add performance regression harness

### DIFF
--- a/README.md
+++ b/README.md
@@ -328,12 +328,19 @@ For Phase 5 UI hardening we rely on a streamlined Vitest setup that targets the
 - `npm run lint` – ESLint with `--max-warnings=0` across the repo.
 - `npm run test:fast` – Vitest in jsdom mode without coverage for quick iteration.
 - `npm run test:coverage` – Vitest + `@vitest/coverage-v8` (text-summary + lcov) with offline guards and console noise enforcement via `src/setupTests.ts`.
+- `npm run test:perf` – Synthetic 12k-transaction ledger processed through the holdings builder; fails if runtime exceeds **1 000 ms** or the NAV series is inconsistent. Structured JSON logs emit duration, heap delta, and NAV samples for CI dashboards.
+
+Sample output (newline-delimited JSON for log aggregation):
+
+```json
+{"ts":"2025-10-08T04:26:43.158Z","level":"info","event":"perf_metric","metric":"holdings_builder_duration","transactionCount":12289,"dateCount":3073,"thresholdMs":1000,"durationMs":197.01,"heapDeltaMb":10.146,"navSample":1504363.75}
+```
 - `npm run build` – Production build through Vite.
 
 The shared test harness automatically opts into the React Router v7 transition behaviour, restores console spies between tests, and sets `process.env.NO_NETWORK_TESTS = '1'` to guarantee offline execution. Tests should stub API layers (`src/utils/api.js`) or other network clients explicitly.
 
-| Name              | Type   | Default | Required | Description |
-| ----------------- | ------ | ------- | -------- | ----------- |
+| Name               | Type   | Default | Required | Description |
+| ------------------ | ------ | ------- | -------- | ----------- |
 | `NO_NETWORK_TESTS` | string | `'1'`   | No       | Forces component tests to remain offline; mock fetchers/HTTP clients instead of performing live calls. |
 
 ## Continuous Integration

--- a/docs/HARDENING_SCOREBOARD.md
+++ b/docs/HARDENING_SCOREBOARD.md
@@ -72,7 +72,7 @@ controls (API key policy, audit logging, request tracing) revalidated against
 |-----------|--------------------------------------------|----------------------------------------|--------|----|-----------------------------|-------|
 | P5-TEST-1 | Frontend component coverage expansion      | DONE                                   | fix/p5-test-1-rescue | —  | `npm run lint`; `npm run test:coverage`; `npm run build` — Coverage (Statements 29.23%, Branches 54.54%, Functions 45.45%, Lines 29.23%) — 3 Vitest specs |
               | Address audit gap on limited React component tests (tab navigation, form validation, holdings table) before Phase 5 coding.【F:comprehensive_audit_v3.md†L66-L93】 |
-| P5-TEST-2 | Performance & load regression harness       | TODO                                   | —      | —  | —                           | Implement 10k-transaction stress suite with runtime thresholds per audit performance recommendations.【F:comprehensive_audit_v3.md†L88-L100】 |
+| P5-TEST-2 | Performance & load regression harness       | DONE                                   | feat/p5-test-2-perf-harness | —  | `npm run test:perf` (`9b1107†L1-L4`) | Structured JSON harness generates 12 288+ trades, verifies holdings build <1 000 ms (197 ms observed), logs heap deltas, and documents CI caveats in README/testing-strategy. |
 | P5-CI-1   | End-to-end & CI reliability automation     | TODO                                   | —      | —  | —                           | Introduce Playwright/Cypress smoke flows and document CI wiring to cover missing E2E coverage noted in the audit.【F:comprehensive_audit_v3.md†L100-L105】 |
 
 ## Security Metrics Snapshot

--- a/docs/testing-strategy.md
+++ b/docs/testing-strategy.md
@@ -59,6 +59,17 @@ Review `reports/mutation/mutation.html` for surviving mutants and update asserti
 
 `npm run test:stress` executes the full Vitest suite five consecutive times without coverage. This surfaces hidden order dependencies and race conditions. Ensure the command finishes cleanly before merging large refactors or flaky-test fixes.
 
+## Performance Regression Harness
+
+`npm run test:perf` drives the synthetic ledger generator under `tools/perf/` to create at least 12 288 trades (plus the seed deposit) and times `computeDailyStates` in the finance module. The harness:
+
+- warms the holdings builder once to stabilize the Node.js JIT,
+- enforces a **1 000 ms** maximum runtime for the holdings projection,
+- validates NAV integrity and state length, and
+- emits newline-delimited JSON metrics (`durationMs`, `heapDeltaMb`, `navSample`) suitable for CI log scraping.
+
+Regressions should be triaged by comparing the structured logs over time. When environment constraints prevent sub-second results (e.g., under heavy CI contention), note the delta in the PR and follow up with optimization tasks.
+
 ## Console Warning Policy
 
 Tests fail fast on console warnings/errors via `setupTests` hooks (`server/__tests__/setup/global.js` and `src/setupTests.ts`). When third-party packages emit unavoidable warnings, isolate them with targeted spies and document the rationale inline. Never mute project warnings globally.
@@ -71,6 +82,7 @@ Use the following commands during local development and CI:
 | --- | --- |
 | `npm test` | Runs the Vitest suite once with coverage enforcement, warning promotion, and deterministic shuffling. |
 | `npm run test:stress` | Executes the suite five times without coverage to detect flakiness. |
+| `npm run test:perf` | Generates a 12k+ transaction ledger and ensures holdings projection completes under 1 000 ms while logging metrics. |
 | `npm run test:mutation` | Invokes StrykerJS against targeted math modules and reports the mutation score. |
 
 For strict deprecation/warning checks, run:

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "test": "vitest run",
     "test:fast": "vitest run --coverage=false --reporter=dot",
     "test:coverage": "vitest run --coverage --coverage.reporter=text-summary --coverage.reporter=lcov",
+    "test:perf": "node tools/perf/run-perf-suite.mjs",
     "leaks:repo": "gitleaks detect --no-banner",
     "audit:quick": "npm audit --audit-level=critical || true",
     "mutate": "stryker run",

--- a/tools/perf/run-perf-suite.mjs
+++ b/tools/perf/run-perf-suite.mjs
@@ -1,0 +1,92 @@
+import { buildSyntheticLedger } from './syntheticLedger.js';
+import { computeDailyStates } from '../../server/finance/portfolio.js';
+
+const HOLDINGS_THRESHOLD_MS = 1_000;
+const TARGET_TRANSACTION_COUNT = 12_288;
+
+function emitLog(level, payload) {
+  const entry = {
+    ts: new Date().toISOString(),
+    level,
+    ...payload,
+  };
+  console.log(JSON.stringify(entry));
+}
+
+function measureHoldingsBuilder({ transactions, pricesByDate, dates }) {
+  const heapBefore = process.memoryUsage().heapUsed;
+  const start = process.hrtime.bigint();
+  const states = computeDailyStates({ transactions, pricesByDate, dates });
+  const end = process.hrtime.bigint();
+  const heapAfter = process.memoryUsage().heapUsed;
+
+  if (!Array.isArray(states) || states.length !== dates.length) {
+    throw new Error('holdings builder returned mismatched state history');
+  }
+  const lastState = states.at(-1);
+  if (!lastState || typeof lastState.nav !== 'number' || Number.isNaN(lastState.nav)) {
+    throw new Error('holdings builder produced invalid NAV metrics');
+  }
+
+  const durationMs = Number(end - start) / 1_000_000;
+  const heapDeltaMb = Number(((heapAfter - heapBefore) / 1024 / 1024).toFixed(3));
+
+  if (durationMs > HOLDINGS_THRESHOLD_MS) {
+    throw new Error(
+      `holdings builder exceeded ${HOLDINGS_THRESHOLD_MS}ms threshold (${durationMs.toFixed(2)}ms)`,
+    );
+  }
+
+  return {
+    durationMs: Number(durationMs.toFixed(2)),
+    heapDeltaMb,
+    navSample: Number(lastState.nav.toFixed(2)),
+  };
+}
+
+function runHoldingsBuilderPerf() {
+  const ledger = buildSyntheticLedger({ transactionCount: TARGET_TRANSACTION_COUNT });
+  if (ledger.transactions.length - 1 < TARGET_TRANSACTION_COUNT) {
+    throw new Error('synthetic ledger did not meet minimum transaction count');
+  }
+
+  // Warm-up pass to stabilize JIT before measurement.
+  computeDailyStates(ledger);
+
+  const metrics = measureHoldingsBuilder(ledger);
+  emitLog('info', {
+    event: 'perf_metric',
+    metric: 'holdings_builder_duration',
+    transactionCount: ledger.transactions.length,
+    dateCount: ledger.dates.length,
+    thresholdMs: HOLDINGS_THRESHOLD_MS,
+    durationMs: metrics.durationMs,
+    heapDeltaMb: metrics.heapDeltaMb,
+    navSample: metrics.navSample,
+  });
+}
+
+function main() {
+  emitLog('info', { event: 'perf_suite_start', suite: 'p5-test-2' });
+  try {
+    runHoldingsBuilderPerf();
+    emitLog('info', { event: 'perf_suite_complete', suite: 'p5-test-2', status: 'pass' });
+  } catch (error) {
+    emitLog('error', {
+      event: 'perf_suite_complete',
+      suite: 'p5-test-2',
+      status: 'fail',
+      message: error.message,
+    });
+    if (error?.stack) {
+      emitLog('debug', {
+        event: 'perf_error_stack',
+        suite: 'p5-test-2',
+        stack: error.stack,
+      });
+    }
+    process.exitCode = 1;
+  }
+}
+
+main();

--- a/tools/perf/syntheticLedger.js
+++ b/tools/perf/syntheticLedger.js
@@ -1,0 +1,143 @@
+import { toDateKey } from '../../server/finance/cash.js';
+
+const DEFAULT_TRANSACTION_COUNT = 10_240;
+const DEFAULT_TICKERS = ['SPY', 'QQQ', 'IWM', 'VTI'];
+const MS_PER_DAY = 86_400_000;
+
+function createDeterministicRng(seed = 17) {
+  let state = BigInt(seed);
+  const modulus = 2_147_483_647n;
+  const multiplier = 48_271n;
+  return () => {
+    state = (state * multiplier) % modulus;
+    return Number(state) / Number(modulus);
+  };
+}
+
+function resolveTradeQuantity(rngValue) {
+  const base = 0.15 + rngValue * 0.4;
+  return Number(base.toFixed(4));
+}
+
+function calculatePrice({ tickerIndex, dayIndex }) {
+  const base = 100 + tickerIndex * 3.25;
+  const drift = dayIndex * 0.12;
+  return Number((base + drift).toFixed(2));
+}
+
+function determineType({ ticker, holdings, rngValue, saleFrequency }) {
+  const held = holdings.get(ticker) ?? 0;
+  if (held <= 0) {
+    return 'BUY';
+  }
+  if (saleFrequency <= 0) {
+    return 'BUY';
+  }
+  return rngValue < saleFrequency ? 'SELL' : 'BUY';
+}
+
+function generateTransactions({
+  transactionCount,
+  tickers,
+  baseDate,
+  saleFrequency,
+}) {
+  const rng = createDeterministicRng(11);
+  const transactions = [
+    {
+      id: 'seed-deposit',
+      seq: 0,
+      createdAt: 0,
+      date: toDateKey(baseDate),
+      type: 'DEPOSIT',
+      amount: 1_000_000,
+    },
+  ];
+
+  const holdings = new Map();
+  const dateKeys = new Set([toDateKey(baseDate)]);
+
+  for (let index = 0; index < transactionCount; index += 1) {
+    const rngValue = rng();
+    const ticker = tickers[index % tickers.length];
+    const dayIndex = Math.floor(index / tickers.length) + 1;
+    const date = toDateKey(new Date(baseDate.getTime() + dayIndex * MS_PER_DAY));
+    const quantity = resolveTradeQuantity(rngValue);
+    const tradeType = determineType({ ticker, holdings, rngValue, saleFrequency });
+    const signedQuantity = tradeType === 'SELL' ? -quantity : quantity;
+    const price = calculatePrice({ tickerIndex: tickers.indexOf(ticker), dayIndex });
+    const amount = Number((Math.abs(signedQuantity) * price).toFixed(2));
+
+    const currentHolding = holdings.get(ticker) ?? 0;
+    const nextHolding = currentHolding + signedQuantity;
+    if (nextHolding < 0) {
+      holdings.set(ticker, currentHolding + quantity);
+      transactions.push({
+        id: `tx-${index}`,
+        seq: index + 1,
+        createdAt: index + 1,
+        date,
+        type: 'BUY',
+        ticker,
+        quantity,
+        amount,
+      });
+    } else {
+      holdings.set(ticker, nextHolding);
+      transactions.push({
+        id: `tx-${index}`,
+        seq: index + 1,
+        createdAt: index + 1,
+        date,
+        type: tradeType,
+        ticker,
+        quantity: signedQuantity,
+        amount,
+      });
+    }
+    dateKeys.add(date);
+  }
+
+  return { transactions, dateKeys };
+}
+
+function buildPriceMap({ tickers, sortedDates }) {
+  const pricesByDate = new Map();
+  for (const [dateIndex, dateKey] of sortedDates.entries()) {
+    const priceMap = new Map();
+    for (const [tickerIndex, ticker] of tickers.entries()) {
+      priceMap.set(ticker, calculatePrice({ tickerIndex, dayIndex: dateIndex }));
+    }
+    pricesByDate.set(dateKey, priceMap);
+  }
+  return pricesByDate;
+}
+
+export function buildSyntheticLedger({
+  transactionCount = DEFAULT_TRANSACTION_COUNT,
+  tickers = DEFAULT_TICKERS,
+  baseDate = new Date('2024-01-01T00:00:00Z'),
+  saleFrequency = 0.3,
+} = {}) {
+  if (!Number.isInteger(transactionCount) || transactionCount < 1) {
+    throw new Error('transactionCount must be a positive integer');
+  }
+  if (!Array.isArray(tickers) || tickers.length === 0) {
+    throw new Error('tickers must be a non-empty array');
+  }
+
+  const { transactions, dateKeys } = generateTransactions({
+    transactionCount,
+    tickers,
+    baseDate,
+    saleFrequency,
+  });
+  const sortedDates = Array.from(dateKeys).sort((a, b) => a.localeCompare(b));
+  const pricesByDate = buildPriceMap({ tickers, sortedDates });
+
+  return {
+    transactions,
+    pricesByDate,
+    dates: sortedDates,
+  };
+}


### PR DESCRIPTION
## Summary
- add a deterministic synthetic ledger generator and performance harness that enforces the <1s holdings builder SLA with structured metrics
- wire the harness into `npm run test:perf` and document execution/interpretation guidance in the README and testing strategy
- update the Phase 5 scoreboard to mark P5-TEST-2 complete with recorded evidence

## Testing
- npm run lint
- npm test -- --coverage
- npm run test:perf
- npm run build

## Compliance
📊 COMPLIANCE: 6/7 rules met (R2 scanner execution deferred to CI)
🤖 Model: gpt-5-codex-high
🧪 Tests: created (perf harness); coverage 29.23% statements / 54.54% branches / 45.45% functions / 29.23% lines
🔐 Security: bandit/gitleaks/pip-audit deferred to CI
⚠️ Failed: R2

------
https://chatgpt.com/codex/tasks/task_e_68e5e756ba2c832f9836e9c881e03ded