### PR TITLE
fix: include CORS headers in Playwright JSON responses

### DIFF
--- a/e2e/dashboard-smoke.spec.ts
+++ b/e2e/dashboard-smoke.spec.ts
@@ -87,10 +87,16 @@ const securityEvents = {
   data: [],
 };
 
+const corsHeaders = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Headers": "Content-Type, Authorization",
+  "Access-Control-Allow-Methods": "GET,POST,OPTIONS",
+} as const;
+
 function jsonResponse(payload: Json) {
   return {
     status: 200,
-    headers: { "content-type": "application/json" },
+    headers: { ...corsHeaders, "content-type": "application/json" },
     body: JSON.stringify(payload),
   } as const;
 }


### PR DESCRIPTION
## Summary
- add a reusable corsHeaders constant for the smoke-test network stubs
- include access-control headers in jsonResponse so mocked GET/POST fulfillments match the OPTIONS preflight

## Testing
- npm run lint
- NO_NETWORK_TESTS=1 npm run test:fast *(fails: vitest: not found; deferred to CI)*

## Compliance Report
📊 COMPLIANCE: 6/7 rules met (Missing: R3 - vitest binary unavailable locally; deferred to CI)
🤖 Model: gpt-5-codex-medium
🧪 Tests: updated (coverage: deferred to CI)
🔐 Security: bandit/gitleaks/pip-audit deferred to CI
⚠️ Failed: R3


------
https://chatgpt.com/codex/tasks/task_e_68e5fc0c3b64832fb1bf1225eb0dfce6