### PR TITLE
fix: include portfolio headers in mock cors responses

### DIFF
--- a/e2e/dashboard-smoke.spec.ts
+++ b/e2e/dashboard-smoke.spec.ts
@@ -89,7 +89,12 @@ const securityEvents = {
 
 const corsHeaders = {
   "Access-Control-Allow-Origin": "*",
-  "Access-Control-Allow-Headers": "Content-Type, Authorization",
+  "Access-Control-Allow-Headers": [
+    "Content-Type",
+    "Authorization",
+    "X-Portfolio-Key",
+    "X-Portfolio-Key-New",
+  ].join(", "),
   "Access-Control-Allow-Methods": "GET,POST,OPTIONS",
 } as const;
 


### PR DESCRIPTION
## Summary
- extend the Playwright mock CORS headers to include the portfolio authentication headers expected by the client

## Testing
- npm run lint

📊 COMPLIANCE: 6/7 rules met (R3 deferred to CI for coverage confirmation)
🤖 Model: gpt-5-codex-medium
🧪 Tests: none (deferred to CI for coverage verification)
🔐 Security: bandit/gitleaks/pip-audit deferred (FAST lane scope)
⚠️ Failed: R3


------
https://chatgpt.com/codex/tasks/task_e_68e5fe93c968832fb44ff2916aa6697a