### PR TITLE
[codex] remove obsolete Node 24 forcing flag

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,9 +29,6 @@ on:
       - 'test-results/**'
   workflow_call:
 
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
-
 permissions:
   contents: read
 

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -27,9 +27,6 @@ concurrency:
   group: pages
   cancel-in-progress: true
 
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
-
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## What changed

- Removed the obsolete `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24` workflow environment setting.
- Kept the repository's intentional project/runtime Node version configuration unchanged.

## Why

GitHub-hosted Actions runners now use Node 24 by default. The pre-migration forcing flag is redundant and can cause workflow failures after the migration.

## Impact

JavaScript actions use the runner's default Node 24 runtime without an obsolete override. Application runtime behavior is unchanged.

## Validation

- Workflow YAML parsed successfully.
- `git diff --check` passed.
- Confirmed the forcing flag no longer appears in `.github/`.

## Rollback

Revert this commit.
